### PR TITLE
Added support "Expandable blockquote" feature from Bot API 7.4

### DIFF
--- a/telers/src/types/message_entity.rs
+++ b/telers/src/types/message_entity.rs
@@ -34,6 +34,7 @@ pub enum Kind {
     Strikethrough,
     Spoiler,
     Blockquote,
+    ExpandableBlockquote,
     Code,
     Pre(Pre),
     TextLink(TextLink),
@@ -170,13 +171,18 @@ impl MessageEntity {
     }
 
     #[must_use]
+    pub fn new_code(offset: u16, length: u16) -> Self {
+        Self::new(offset, length, Kind::Code)
+    }
+
+    #[must_use]
     pub fn new_blockquote(offset: u16, length: u16) -> Self {
         Self::new(offset, length, Kind::Blockquote)
     }
 
     #[must_use]
-    pub fn new_code(offset: u16, length: u16) -> Self {
-        Self::new(offset, length, Kind::Code)
+    pub fn new_expandable_blockquote(offset: u16, length: u16) -> Self {
+        Self::new(offset, length, Kind::ExpandableBlockquote)
     }
 
     #[must_use]

--- a/telers/src/utils/text/html_formatter.rs
+++ b/telers/src/utils/text/html_formatter.rs
@@ -235,6 +235,7 @@ impl TextFormatter for Formatter {
             MessageEntityKind::Strikethrough => self.strikethrough(editable_text),
             MessageEntityKind::Spoiler => self.spoiler(editable_text),
             MessageEntityKind::Blockquote => self.blockquote(editable_text),
+            MessageEntityKind::ExpandableBlockquote => self.blockquote(editable_text),
             MessageEntityKind::Code => self.code(editable_text),
             MessageEntityKind::Pre(PreMessageEntity { language }) => match language {
                 Some(language) => self.pre_language(editable_text, language),

--- a/telers/src/utils/text/markdown_formatter.rs
+++ b/telers/src/utils/text/markdown_formatter.rs
@@ -180,6 +180,7 @@ impl TextFormatter for Formatter {
             MessageEntityKind::Strikethrough => self.strikethrough(editable_text),
             MessageEntityKind::Spoiler => self.spoiler(editable_text),
             MessageEntityKind::Blockquote => self.blockquote(editable_text),
+            MessageEntityKind::ExpandableBlockquote => self.blockquote(editable_text),
             MessageEntityKind::Code => self.code(editable_text),
             MessageEntityKind::Pre(PreMessageEntity { language }) => match language {
                 Some(language) => self.pre_language(editable_text, language),


### PR DESCRIPTION
A few days ago Bot API 7.4 was released, and it featured new entities - expandable blockquote.
```
...
Added support for “expandable_blockquote” entities in received messages.
Added support for “expandable_blockquote” entity parsing in “MarkdownV2” and “HTML” parse mode
...
```
Bot, written on telers, can't process message with new kind entity, and as result, bot will temporarily stop working. I suggest you to merge my branch with new Bot API feature.