### PR TITLE
Add specify extensions and context in builder

### DIFF
--- a/examples/context/src/main.rs
+++ b/examples/context/src/main.rs
@@ -25,11 +25,15 @@ use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt
 // We use `FromContext` here to implement `Extractor` for `Data` which extract it to handler arguments automatically.
 // Check `extractor` module for more information.
 #[derive(Debug, Clone, PartialEq, Eq, FromContext)]
-#[context(key = "data")]
-struct Data(i64);
+#[context(key = "data1")]
+struct Data1(i64);
+
+#[derive(Debug, Clone, PartialEq, Eq, FromContext)]
+#[context(key = "data2")]
+struct Data2(i64);
 
 async fn to_context_middleware(mut request: Request) -> Result<MiddlewareResponse, EventErrorKind> {
-    request.context.insert("data", Data(1));
+    request.context.insert("data1", Data1(1));
 
     Ok((request, EventReturn::default()))
 }
@@ -38,15 +42,17 @@ async fn send_data_handler(
     bot: Bot,
     message: Message,
     // Data has been extracted automatically
-    data: Data,
+    data1: Data1,
+    data2: Data2,
     // You can use context by yourself to extract data
     context: Context,
 ) -> HandlerResult {
-    assert_eq!(data, context.get::<Data>("data").unwrap().clone(),);
+    assert_eq!(data1, context.get::<Data1>("data1").unwrap().clone());
+    assert_eq!(data2, context.get::<Data2>("data2").unwrap().clone());
 
     bot.send(SendMessage::new(
         message.chat().id(),
-        format!("Data: {}", data.0),
+        format!("Data1: {}. Data2: {}", data1.0, data2.0),
     ))
     .await?;
 
@@ -80,6 +86,8 @@ async fn main() {
     let mut dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
+        // You also can insert data in context using builder methods
+        .context("data2", Data2(2))
         .allowed_update(UpdateType::Message)
         .build();
 

--- a/examples/extensions/src/main.rs
+++ b/examples/extensions/src/main.rs
@@ -29,6 +29,9 @@ struct NumData(i64);
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct StrData(&'static str);
 
+#[derive(Clone)]
+struct EmptyData;
+
 async fn to_extensions_middleware(
     mut request: Request,
 ) -> Result<MiddlewareResponse, EventErrorKind> {
@@ -49,6 +52,7 @@ async fn send_data_handler(
     // Data has been extracted automatically
     Extension(num_data): Extension<NumData>,
     Extension(str_data): Extension<StrData>,
+    Extension(_): Extension<EmptyData>,
     // You can use extensions by yourself to extract data
     extensions: Extensions,
 ) -> HandlerResult {
@@ -92,6 +96,8 @@ async fn main() {
     let mut dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
+        // You also can register an extension using builder methods
+        .extension(EmptyData)
         .allowed_update(UpdateType::Message)
         .build();
 

--- a/examples/extractor/src/main.rs
+++ b/examples/extractor/src/main.rs
@@ -14,13 +14,12 @@
 use std::convert::Infallible;
 use telers::{
     enums::UpdateType,
-    errors::{ConvertToTypeError, EventErrorKind, ExtractionError},
+    errors::{ConvertToTypeError, ExtractionError},
     event::{telegram::HandlerResult, EventReturn},
     filters::Command,
     methods::SendMessage,
-    middlewares::outer::MiddlewareResponse,
     types::{Message, Update},
-    Bot, Dispatcher, Extension, Extractor, FromContext, FromEvent, Request, Router,
+    Bot, Context, Dispatcher, Extension, Extractor, FromContext, FromEvent, Request, Router,
 };
 use tracing::{event, Level};
 use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
@@ -114,17 +113,6 @@ impl Extractor for BotId {
     }
 }
 
-async fn to_context_and_extensions(
-    mut request: Request,
-) -> Result<MiddlewareResponse, EventErrorKind> {
-    request.context.insert("num_data", NumData(1));
-    request.context.insert("str_data", StrData("1"));
-
-    request.extensions.insert(BoolData(true));
-
-    Ok((request, EventReturn::default()))
-}
-
 async fn send_data_handler(
     bot: Bot,
     message: Message,
@@ -163,13 +151,6 @@ async fn main() {
 
     let mut router = Router::new("main");
 
-    // Register middleware that adds data to context and extensions.
-    // Be aware, we register middleware for message observer, so it will be called only for messages.
-    // If you want to register middleware for any update, you should register it for update observer.
-    router
-        .message
-        .outer_middlewares
-        .register(to_context_and_extensions);
     // Register handler that sends extracted data to chat
     router
         .message
@@ -183,6 +164,13 @@ async fn main() {
     let mut dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
+        .context_extend({
+            let mut context = Context::new();
+            context.insert("num_data", NumData(1));
+            context.insert("str_data", StrData("1"));
+            context
+        })
+        .extension(BoolData(true))
         .allowed_update(UpdateType::Message)
         .build();
 

--- a/telers/src/dispatcher.rs
+++ b/telers/src/dispatcher.rs
@@ -196,7 +196,8 @@ impl<Client, Propagator, BackoffType> Builder<Client, Propagator, BackoffType> {
         }
     }
 
-    /// Insert a type into this [`Extensions`].
+    /// Insert a type into this [`Extensions`]
+    #[must_use]
     pub fn context<T>(mut self, key: &'static str, val: T) -> Self
     where
         T: Clone + Send + Sync + 'static,
@@ -206,12 +207,14 @@ impl<Client, Propagator, BackoffType> Builder<Client, Propagator, BackoffType> {
     }
 
     /// Extend context of dispatcher
+    #[must_use]
     pub fn context_extend(mut self, val: Context) -> Self {
         self.context.extend(val);
         self
     }
 
-    /// Insert a type into this [`Extensions`].
+    /// Insert a type into this [`Extensions`]
+    #[must_use]
     pub fn extension<T>(mut self, val: T) -> Self
     where
         T: Clone + Send + Sync + 'static,
@@ -221,6 +224,7 @@ impl<Client, Propagator, BackoffType> Builder<Client, Propagator, BackoffType> {
     }
 
     /// Extend extensions of dispatcher
+    #[must_use]
     pub fn extensions_extend(mut self, val: Extensions) -> Self {
         self.extensions.extend(val);
         self

--- a/telers/src/dispatcher.rs
+++ b/telers/src/dispatcher.rs
@@ -1,5 +1,5 @@
 //! [`Dispatcher`] is the main part of the library, which contains functionality for handling updates and dispatching them to the router.
-//! You can create [`Dispatcher`] with [`Dispatcher::new`] method or using [`Builder`] (**recommended**).
+//! You can create [`Dispatcher`] using [`Builder`].
 //!
 //! Components of the dispatcher:
 //! * [`Bot`]:
@@ -92,49 +92,11 @@ enum PollingError {
 pub struct Dispatcher<Client, Propagator, BackoffType = ExponentialBackoff<SystemClock>> {
     main_router: Propagator,
     bots: Vec<Bot<Client>>,
+    extensions: Extensions,
+    context: Context,
     polling_timeout: Option<i64>,
     backoff: BackoffType,
     allowed_updates: Vec<UpdateType>,
-}
-
-impl<Client, Propagator, BackoffType> Dispatcher<Client, Propagator, BackoffType> {
-    /// Creates new dispatcher
-    /// # Arguments
-    /// * `main_router` -
-    ///     Main router, whose service will propagate updates to the other routers and its observers
-    /// * `bots` -
-    ///     Bots that will be used for getting updates and sending requests.
-    ///     All bots use the same dispatcher, but each bot has the own polling process.
-    ///     Polling process gets updates and propagates them to the main propagator.
-    /// * `polling_timeout` -
-    ///     Timeout in seconds for long polling
-    /// * `backoff` -
-    ///     Backoff used for handling server-side errors and network errors (like connection reset or telegram server is down, etc.)
-    ///     and set timeout between requests to telegram server
-    /// * `allowed_updates` -
-    ///     List the types of updates you want your bot to receive.
-    ///     For example, specify [`UpdateType::Message`], [`UpdateType::EditedChannelPost`], [`UpdateType::CallbackQuery`]
-    ///     to only receive updates of these types.
-    #[must_use]
-    pub fn new(
-        main_router: Propagator,
-        bots: impl IntoIterator<Item = Bot<Client>>,
-        polling_timeout: Option<i64>,
-        backoff: BackoffType,
-        allowed_updates: impl IntoIterator<Item = UpdateType>,
-    ) -> Self
-    where
-        BackoffType: Backoff,
-        Propagator: PropagateEvent<Client>,
-    {
-        Self {
-            main_router,
-            bots: bots.into_iter().collect(),
-            polling_timeout,
-            backoff,
-            allowed_updates: allowed_updates.into_iter().collect(),
-        }
-    }
 }
 
 impl<Client, Propagator> Dispatcher<Client, Propagator>
@@ -147,19 +109,11 @@ where
     }
 }
 
-impl<Client, Propagator, BackoffType> Dispatcher<Client, Propagator, BackoffType>
-where
-    Propagator: Default,
-{
-    #[must_use]
-    pub fn builder_with_backoff(val: BackoffType) -> Builder<Client, Propagator, BackoffType> {
-        Builder::default_with_backoff(val)
-    }
-}
-
 pub struct Builder<Client, Propagator, BackoffType = ExponentialBackoff<SystemClock>> {
     main_router: Propagator,
     bots: Vec<Bot<Client>>,
+    context: Context,
+    extensions: Extensions,
     polling_timeout: Option<i64>,
     backoff: BackoffType,
     allowed_updates: Vec<UpdateType>,
@@ -175,6 +129,8 @@ where
         Self {
             main_router: Propagator::default(),
             bots: vec![],
+            context: Context::new(),
+            extensions: Extensions::new(),
             polling_timeout: Some(DEFAULT_POLLING_TIMEOUT),
             backoff: ExponentialBackoff::default(),
             allowed_updates: vec![],
@@ -182,19 +138,11 @@ where
     }
 }
 
-impl<Client, Propagator, BackoffType> Builder<Client, Propagator, BackoffType>
-where
-    Propagator: Default,
-{
+impl<Client, Propagator, BackoffType> Builder<Client, Propagator, BackoffType> {
     #[must_use]
-    pub fn default_with_backoff(backoff: BackoffType) -> Self {
-        Self {
-            main_router: Propagator::default(),
-            bots: vec![],
-            polling_timeout: Some(DEFAULT_POLLING_TIMEOUT),
-            backoff,
-            allowed_updates: vec![],
-        }
+    pub fn with_backoff(mut self, backoff: BackoffType) -> Self {
+        self.backoff = backoff;
+        self
     }
 }
 
@@ -248,6 +196,36 @@ impl<Client, Propagator, BackoffType> Builder<Client, Propagator, BackoffType> {
         }
     }
 
+    /// Insert a type into this [`Extensions`].
+    pub fn context<T>(mut self, key: &'static str, val: T) -> Self
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        self.context.insert(key, val);
+        self
+    }
+
+    /// Extend context of dispatcher
+    pub fn context_extend(mut self, val: Context) -> Self {
+        self.context.extend(val);
+        self
+    }
+
+    /// Insert a type into this [`Extensions`].
+    pub fn extension<T>(mut self, val: T) -> Self
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        self.extensions.insert(val);
+        self
+    }
+
+    /// Extend extensions of dispatcher
+    pub fn extensions_extend(mut self, val: Extensions) -> Self {
+        self.extensions.extend(val);
+        self
+    }
+
     /// Timeout in seconds for long polling
     /// # Default
     /// [`DEFAULT_POLLING_TIMEOUT`]
@@ -299,6 +277,8 @@ impl<Client, Propagator, BackoffType> Builder<Client, Propagator, BackoffType> {
         Dispatcher {
             main_router: self.main_router,
             bots: self.bots,
+            extensions: self.extensions,
+            context: self.context,
             polling_timeout: self.polling_timeout,
             backoff: self.backoff,
             allowed_updates: self.allowed_updates,
@@ -309,29 +289,11 @@ impl<Client, Propagator, BackoffType> Builder<Client, Propagator, BackoffType> {
 impl<Client, PropagatorService, BackoffType> Dispatcher<Client, PropagatorService, BackoffType> {
     /// Main entry point for incoming updates.
     /// This method will propagate update to the main router.
-    #[allow(clippy::missing_errors_doc)]
+    #[instrument(skip_all, fields(update_id = update.id, update_type))]
     pub async fn feed_update(
         &mut self,
         bot: Bot<Client>,
         update: Arc<Update>,
-    ) -> Result<Response<Client>, EventErrorKind>
-    where
-        Client: Send + Sync + Clone + 'static,
-        PropagatorService: PropagateEvent<Client>,
-    {
-        self.feed_update_with_context(bot, update, Context::new(), Extensions::new())
-            .await
-    }
-
-    /// Main entry point for incoming updates with user context.
-    /// This method will propagate update to the main router.
-    #[instrument(name = "feed_update", skip_all, fields(update_id = update.id, update_type))]
-    pub async fn feed_update_with_context(
-        &mut self,
-        bot: Bot<Client>,
-        update: Arc<Update>,
-        context: Context,
-        extensions: Extensions,
     ) -> Result<Response<Client>, EventErrorKind>
     where
         Client: Send + Sync + Clone + 'static,
@@ -347,8 +309,8 @@ impl<Client, PropagatorService, BackoffType> Dispatcher<Client, PropagatorServic
                 Request {
                     bot,
                     update,
-                    context,
-                    extensions,
+                    context: self.context.clone(),
+                    extensions: self.extensions.clone(),
                 },
             )
             .await
@@ -692,6 +654,15 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct Test1;
+
+    #[derive(Clone)]
+    struct Test2;
+
+    #[derive(Clone)]
+    struct Test3;
+
     #[test]
     fn test_builder() {
         let bot = Bot::<Reqwest>::default();
@@ -700,12 +671,28 @@ mod tests {
             .main_router(Router::new("main").configure_default())
             .bot(bot.clone())
             .bots([bot])
+            .extension(Test1)
+            .extension(Test2)
+            .extensions_extend({
+                let mut extensions = Extensions::new();
+                extensions.insert(Test3);
+                extensions
+            })
+            .context("1", Test1)
+            .context("2", Test2)
+            .context_extend({
+                let mut context = Context::new();
+                context.insert("3", Test3);
+                context
+            })
             .polling_timeout(123)
             .allowed_update(UpdateType::Message)
             .allowed_updates([UpdateType::InlineQuery, UpdateType::ChosenInlineResult])
             .build();
 
         assert_eq!(dispatcher.bots.len(), 2);
+        assert_eq!(dispatcher.extensions.len(), 3);
+        assert_eq!(dispatcher.context.len(), 3);
         assert_eq!(dispatcher.polling_timeout, Some(123));
         assert_eq!(dispatcher.allowed_updates.len(), 3);
     }

--- a/telers/src/extensions.rs
+++ b/telers/src/extensions.rs
@@ -1,5 +1,5 @@
 //! [`Extension`] is a type that is used to transmit data between processing-units when propagating an event.
-//! [`Extensions`] creates at the start of the event propagation by [`Dispatcher`] and pass to every processing-unit.
+//! Extensions creates at the start of the event propagation by [`Dispatcher`] and pass to every processing-unit.
 //! Processing-units can add their own data to extension and use data from extension that was added by others.
 //!
 //! Modify extensions in outer middlewares if you need to pass some data to next outer/inner middlewares or to filters.
@@ -51,16 +51,6 @@ impl Extensions {
         Self { map: None }
     }
 
-    /// Insert a type into this [`Extensions`].
-    /// If the map did not have this key present, [`None`] is returned.
-    /// If a extension of this type already existed, it will be returned and replaced with the new one.
-    /// # Examples
-    /// ```
-    /// let mut ext = Extensions::new();
-    /// assert!(ext.insert(5i32).is_none());
-    /// assert!(ext.insert(4u8).is_none());
-    /// assert_eq!(ext.insert(9i32), Some(5i32));
-    /// ```
     pub fn insert<T: Clone + Send + Sync + 'static>(&mut self, val: T) -> Option<T> {
         self.map
             .get_or_insert_with(Box::default)
@@ -68,15 +58,6 @@ impl Extensions {
             .and_then(|boxed| boxed.into_any().downcast().ok().map(|boxed| *boxed))
     }
 
-    /// Get a reference to a type previously inserted on this [`Extensions`]
-    /// # Examples
-    /// ```
-    /// let mut ext = Extensions::new();
-    /// assert!(ext.get::<i32>().is_none());
-    /// ext.insert(5i32);
-    ///
-    /// assert_eq!(ext.get::<i32>(), Some(&5i32));
-    /// ```
     #[must_use]
     pub fn get<T: 'static>(&self) -> Option<&T> {
         self.map
@@ -85,15 +66,6 @@ impl Extensions {
             .and_then(|boxed| (**boxed).as_any().downcast_ref())
     }
 
-    /// Get a mutable reference to a type previously inserted on this [`Extensions`]
-    /// # Examples
-    /// ```
-    /// let mut ext = Extensions::new();
-    /// ext.insert(String::from("Hello"));
-    /// ext.get_mut::<String>().unwrap().push_str(" World");
-    ///
-    /// assert_eq!(ext.get::<String>().unwrap(), "Hello World");
-    /// ```
     pub fn get_mut<T: 'static>(&mut self) -> Option<&mut T> {
         self.map
             .as_mut()
@@ -101,14 +73,6 @@ impl Extensions {
             .and_then(|boxed| (**boxed).as_any_mut().downcast_mut())
     }
 
-    /// Get a mutable reference to a type, inserting the value created by `f` if not already present on this [`Extensions`]
-    /// # Examples
-    /// ```
-    /// let mut ext = Extensions::new();
-    /// *ext.get_or_insert_with(|| 1i32) += 2;
-    ///
-    /// assert_eq!(*ext.get::<i32>().unwrap(), 3);
-    /// ```
     #[allow(clippy::missing_panics_doc)]
     pub fn get_or_insert_with<T: Clone + Send + Sync + 'static, F: FnOnce() -> T>(
         &mut self,
@@ -122,39 +86,14 @@ impl Extensions {
         (**out).as_any_mut().downcast_mut().unwrap()
     }
 
-    /// Get a mutable reference to a type, inserting `value` if not already present on this [`Extensions`]
-    /// # Examples
-    /// ```
-    /// let mut ext = Extensions::new();
-    /// *ext.get_or_insert(1i32) += 2;
-    ///
-    /// assert_eq!(*ext.get::<i32>().unwrap(), 3);
-    /// ```
     pub fn get_or_insert<T: Clone + Send + Sync + 'static>(&mut self, value: T) -> &mut T {
         self.get_or_insert_with(|| value)
     }
 
-    /// Get a mutable reference to a type, inserting the type's default value if not already present on this [`Extensions`]
-    /// # Examples
-    /// ```
-    /// let mut ext = Extensions::new();
-    /// *ext.get_or_insert_default::<i32>() += 2;
-    ///
-    /// assert_eq!(*ext.get::<i32>().unwrap(), 2);
-    /// ```
     pub fn get_or_insert_default<T: Default + Clone + Send + Sync + 'static>(&mut self) -> &mut T {
         self.get_or_insert_with(T::default)
     }
 
-    /// Remove a type from this [`Extensions`].
-    /// If a extension of this type existed, it will be returned.
-    /// # Examples
-    /// ```
-    /// let mut ext = Extensions::new();
-    /// ext.insert(5i32);
-    /// assert_eq!(ext.remove::<i32>(), Some(5i32));
-    /// assert!(ext.get::<i32>().is_none());
-    /// ```
     pub fn remove<T: 'static>(&mut self) -> Option<T> {
         self.map
             .as_mut()
@@ -162,15 +101,6 @@ impl Extensions {
             .and_then(|boxed| boxed.into_any().downcast().ok().map(|boxed| *boxed))
     }
 
-    /// Clear the [`Extensions`] of all inserted extensions
-    /// # Examples
-    /// ```
-    /// let mut ext = Extensions::new();
-    /// ext.insert(5i32);
-    /// ext.clear();
-    ///
-    /// assert!(ext.get::<i32>().is_none());
-    /// ```
     #[inline]
     pub fn clear(&mut self) {
         if let Some(ref mut map) = self.map {
@@ -178,52 +108,18 @@ impl Extensions {
         }
     }
 
-    /// Check whether the extension set is empty or not
-    /// # Examples
-    /// ```
-    /// let mut ext = Extensions::new();
-    /// assert!(ext.is_empty());
-    /// ext.insert(5i32);
-    /// assert!(!ext.is_empty());
-    /// ```
     #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.map.as_ref().map_or(true, |map| map.is_empty())
     }
 
-    /// Get the number of extensions available
-    /// # Examples
-    /// ```
-    /// let mut ext = Extensions::new();
-    /// assert_eq!(ext.len(), 0);
-    /// ext.insert(5i32);
-    /// assert_eq!(ext.len(), 1);
-    /// ```
     #[inline]
     #[must_use]
     pub fn len(&self) -> usize {
         self.map.as_ref().map_or(0, |map| map.len())
     }
 
-    /// Extends `self` with another [`Extensions`].
-    /// If an instance of a specific type exists in both, the one in `self` is overwritten with the one from `other`.
-    /// # Examples
-    /// ```
-    /// let mut ext_a = Extensions::new();
-    /// ext_a.insert(8u8);
-    /// ext_a.insert(16u16);
-    ///
-    /// let mut ext_b = Extensions::new();
-    /// ext_b.insert(4u8);
-    /// ext_b.insert("hello");
-    ///
-    /// ext_a.extend(ext_b);
-    /// assert_eq!(ext_a.len(), 3);
-    /// assert_eq!(ext_a.get::<u8>(), Some(&4u8));
-    /// assert_eq!(ext_a.get::<u16>(), Some(&16u16));
-    /// assert_eq!(ext_a.get::<&'static str>().copied(), Some("hello"));
-    /// ```
     pub fn extend(&mut self, other: Self) {
         if let Some(other) = other.map {
             if let Some(map) = &mut self.map {


### PR DESCRIPTION
Added methods `extension`, `extensions_extend`, `context` and `context_extend` to pass data from the start of application.

Examples:
- https://github.com/Desiders/telers/blob/dev-1.x/examples/context/src/main.rs#L90
- https://github.com/Desiders/telers/blob/dev-1.x/examples/extensions/src/main.rs#L100
- https://github.com/Desiders/telers/blob/dev-1.x/examples/extractor/src/main.rs#L167-L173