### PR TITLE
Add graceful shutdown system

### DIFF
--- a/examples/axum_and_echo_bot/Cargo.toml
+++ b/examples/axum_and_echo_bot/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.66"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers" }
+telers = { path = "../../telers", features = ["signal"] }
 tokio = { version = "1.28", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } 

--- a/examples/axum_and_echo_bot/Cargo.toml
+++ b/examples/axum_and_echo_bot/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.66"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers" }
 tokio = { version = "1.28", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } 

--- a/examples/axum_and_echo_bot/src/main.rs
+++ b/examples/axum_and_echo_bot/src/main.rs
@@ -86,6 +86,6 @@ async fn run_dispatcher(dispatcher: Dispatcher, mut shutdown_rx: Receiver<()>) {
 }
 
 async fn handle_shutdown(shutdown_tx: Sender<()>) {
-    let _ = shutdown_signal().await;
+    let () = shutdown_signal().await;
     let _ = shutdown_tx.send(());
 }

--- a/examples/axum_and_echo_bot/src/main.rs
+++ b/examples/axum_and_echo_bot/src/main.rs
@@ -11,10 +11,13 @@ use telers::{
     event::{telegram::HandlerResult, EventReturn},
     methods::CopyMessage,
     types::Message,
+    utils::shutdown_signal,
     Bot, Dispatcher, Router as TelersRouter,
 };
-use tokio::net::TcpListener;
-use tracing::{event, Level};
+use tokio::{
+    net::TcpListener,
+    sync::broadcast::{channel, Receiver, Sender},
+};
 use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 async fn echo_handler(bot: Bot, message: Message) -> HandlerResult {
@@ -51,43 +54,38 @@ async fn main() {
         .allowed_update(UpdateType::Message)
         .build();
 
-    let app = AxumRouter::new()
-        .route("/", routing::get(hello_world_handler))
-        .into_make_service();
+    let app = AxumRouter::new().route("/", routing::get(hello_world_handler));
 
-    // `tokio::spawn` is used to run polling and server in different threads.
-    // You can also don't use `tokio::spawn` and run them in the same thread.
-    tokio::join!(
-        async {
-            match tokio::spawn(async move { dispatcher.run_polling().await }).await {
-                Ok(Ok(())) => {}
-                Ok(Err(err)) => {
-                    event!(Level::ERROR, "Error in dispatcher: {:?}", err);
-                }
-                Err(err) => {
-                    event!(Level::ERROR, "Dispatcher panicked: {:?}", err);
-                }
-            }
-        },
-        async {
-            // Check graceful shutdown example of axum server:
-            // https://github.com/tokio-rs/axum/tree/main/examples/graceful-shutdown
-            // Telers provides graceful shutdown out of the box, so you don't need to do anything special.
-            match tokio::spawn(async {
-                let listener = TcpListener::bind("0.0.0.0:3000").await?;
+    let (shutdown_tx, _) = channel(1);
 
-                axum::serve(listener, app).await
-            })
-            .await
-            {
-                Ok(Ok(())) => {}
-                Ok(Err(err)) => {
-                    event!(Level::ERROR, "Error in server: {:?}", err);
-                }
-                Err(err) => {
-                    event!(Level::ERROR, "Server panicked: {:?}", err);
-                }
-            }
-        }
+    let _ = tokio::join!(
+        tokio::spawn(run_server(app, shutdown_tx.subscribe())),
+        tokio::spawn(run_dispatcher(dispatcher, shutdown_tx.subscribe())),
+        tokio::spawn(handle_shutdown(shutdown_tx))
     );
+}
+
+async fn run_server(app: axum::Router, mut shutdown_rx: Receiver<()>) {
+    let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            let _ = shutdown_rx.recv().await;
+        })
+        .await
+        .unwrap();
+}
+
+async fn run_dispatcher(dispatcher: Dispatcher, mut shutdown_rx: Receiver<()>) {
+    dispatcher
+        .run_polling()
+        .with_graceful_shutdown(async move {
+            let _ = shutdown_rx.recv().await;
+        })
+        .await
+        .unwrap();
+}
+
+async fn handle_shutdown(shutdown_tx: Sender<()>) {
+    let _ = shutdown_signal().await;
+    let _ = shutdown_tx.send(());
 }

--- a/examples/axum_and_echo_bot/src/main.rs
+++ b/examples/axum_and_echo_bot/src/main.rs
@@ -45,7 +45,7 @@ async fn main() {
     let mut router = TelersRouter::new("main");
     router.message.register(echo_handler);
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         .allowed_update(UpdateType::Message)

--- a/examples/bot_http_client/Cargo.toml
+++ b/examples/bot_http_client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } 

--- a/examples/bot_http_client/src/main.rs
+++ b/examples/bot_http_client/src/main.rs
@@ -98,7 +98,7 @@ async fn main() {
     let mut router = Router::new("main");
     router.message.register(echo_handler);
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         .allowed_update(UpdateType::Message)

--- a/examples/business_connection/Cargo.toml
+++ b/examples/business_connection/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } 

--- a/examples/business_connection/src/main.rs
+++ b/examples/business_connection/src/main.rs
@@ -63,7 +63,7 @@ async fn main() {
     router.edited_business_message.register(message_edited);
     router.deleted_business_messages.register(messages_deleted);
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .allowed_updates(router.resolve_used_update_types())
         .main_router(router.configure_default())
         .bot(bot)

--- a/examples/context/Cargo.toml
+++ b/examples/context/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } 

--- a/examples/context/src/main.rs
+++ b/examples/context/src/main.rs
@@ -83,7 +83,7 @@ async fn main() {
         .register(send_data_handler)
         .filter(Command::one("data"));
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         // You also can insert data in context using builder methods

--- a/examples/echo_bot/Cargo.toml
+++ b/examples/echo_bot/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } 

--- a/examples/echo_bot/src/main.rs
+++ b/examples/echo_bot/src/main.rs
@@ -38,7 +38,7 @@ async fn main() {
     let mut router = Router::new("main");
     router.message.register(echo_handler);
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         .allowed_update(UpdateType::Message)

--- a/examples/extensions/Cargo.toml
+++ b/examples/extensions/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } 

--- a/examples/extensions/src/main.rs
+++ b/examples/extensions/src/main.rs
@@ -93,7 +93,7 @@ async fn main() {
         .register(send_data_handler)
         .filter(Command::one("data"));
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         // You also can register an extension using builder methods

--- a/examples/extractor/Cargo.toml
+++ b/examples/extractor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } 

--- a/examples/extractor/src/main.rs
+++ b/examples/extractor/src/main.rs
@@ -161,7 +161,7 @@ async fn main() {
         .register(update_id_handler)
         .filter(Command::one("update_id"));
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         .context_extend({

--- a/examples/fsm/src/main.rs
+++ b/examples/fsm/src/main.rs
@@ -193,7 +193,7 @@ async fn main() {
         .filter(ContentType::one(ContentTypeEnum::Text))
         .filter(StateFilter::one(State::Language));
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         .allowed_update(UpdateType::Message)

--- a/examples/fsm_and_business_connection/src/main.rs
+++ b/examples/fsm_and_business_connection/src/main.rs
@@ -205,7 +205,7 @@ async fn main() {
         .filter(ContentType::one(ContentTypeEnum::Text))
         .filter(StateFilter::one(State::Language));
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         .allowed_update(UpdateType::BusinessMessage)

--- a/examples/input_file/Cargo.toml
+++ b/examples/input_file/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tokio-util = { version = "0.7.9", features = ["codec"] }
 reqwest = "0.12"

--- a/examples/input_file/src/main.rs
+++ b/examples/input_file/src/main.rs
@@ -152,7 +152,7 @@ async fn main() {
     router.startup.register(on_startup, ());
     router.shutdown.register(on_shutdown, ());
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         .allowed_update(UpdateType::Message)

--- a/examples/random_sticker/Cargo.toml
+++ b/examples/random_sticker/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 rand = "0.9"
 tracing = "0.1"

--- a/examples/random_sticker/src/main.rs
+++ b/examples/random_sticker/src/main.rs
@@ -106,7 +106,7 @@ async fn main() {
         .register(wrong_message_handler)
         .filter(ContentType::one(ContentTypeEnum::Sticker).invert());
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         .allowed_update(UpdateType::Message)

--- a/examples/router_tree/Cargo.toml
+++ b/examples/router_tree/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } 

--- a/examples/router_tree/src/main.rs
+++ b/examples/router_tree/src/main.rs
@@ -127,7 +127,7 @@ async fn main() {
     // Include echo router into main router, so all updates, which are not handled by main router or private router will be passed to echo router
     main_router.include(echo_router);
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .allowed_updates(main_router.resolve_used_update_types())
         .router(main_router.configure_default())
         .bot(bot)

--- a/examples/serialize/Cargo.toml
+++ b/examples/serialize/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } 

--- a/examples/serialize/src/main.rs
+++ b/examples/serialize/src/main.rs
@@ -55,7 +55,7 @@ async fn main() {
     let mut router = Router::new("main");
     router.update.register(serialize_handler);
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         .allowed_updates(UpdateType::all())

--- a/examples/stats_incoming_updates_middleware/Cargo.toml
+++ b/examples/stats_incoming_updates_middleware/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/stats_incoming_updates_middleware/src/main.rs
+++ b/examples/stats_incoming_updates_middleware/src/main.rs
@@ -114,7 +114,7 @@ async fn main() {
         });
     router.message.register(handler);
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         .allowed_updates(UpdateType::all())

--- a/examples/text_case_filters/Cargo.toml
+++ b/examples/text_case_filters/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/text_case_filters/src/main.rs
+++ b/examples/text_case_filters/src/main.rs
@@ -85,7 +85,7 @@ async fn main() {
         .filter(lowercase_filter);
     router.message.register(any_case_handler);
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         .allowed_update(UpdateType::Message)

--- a/examples/text_formatting/Cargo.toml
+++ b/examples/text_formatting/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-telers = { path = "../../telers", features = ["default"] }
+telers = { path = "../../telers", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] } 

--- a/examples/text_formatting/src/main.rs
+++ b/examples/text_formatting/src/main.rs
@@ -68,7 +68,7 @@ async fn main() {
     let mut router = Router::new("main");
     router.message.register(handler);
 
-    let mut dispatcher = Dispatcher::builder()
+    let dispatcher = Dispatcher::builder()
         .main_router(router.configure_default())
         .bot(bot)
         .allowed_update(UpdateType::Message)

--- a/telers/Cargo.toml
+++ b/telers/Cargo.toml
@@ -23,10 +23,17 @@ redis-storage = ["redis", "deadpool-redis"]
 # For possible use memory FSM storage.
 memory-storage = []
 
+# Include realization of shutdown signal handler.
+# Still should be registered manually, it just adds handler.
+# If you want to register it automatically, use `default_signal` feature.
+signal = ["tokio/signal"]
+# Register signal realization automatically in serve
+default_signal = ["signal"]
+
 [dependencies]
 telers-macros = { path = "../telers-macros", version = "1.0.0-alpha.3", features = ["default"] }
 tower = { version = "0.5", default-features = false, features = ["util"] }
-tokio = { version = "1.36", default-features = false, features = ["sync", "macros", "signal", "fs"] }
+tokio = { version = "1.36", default-features = false, features = ["sync", "macros", "fs"] }
 tokio-util = { version = "0.7", default-features = false, features = ["codec"] }
 reqwest = { version = "0.12", default-features = false, features = ["multipart", "stream"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/telers/Cargo.toml
+++ b/telers/Cargo.toml
@@ -15,7 +15,7 @@ default-tls = ["reqwest/default-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 # Include all possible features
-full = ["storages"]
+full = ["storages", "default_signal"]
 # Include all possible storages
 storages = ["redis-storage", "memory-storage"]
 # For possible use redis FSM storage

--- a/telers/src/client/bot.rs
+++ b/telers/src/client/bot.rs
@@ -62,7 +62,7 @@ use std::{
 ///
 /// Check [module docs](crate::client::bot) for examples.
 #[derive(Clone, Default)]
-pub struct Bot<Client: ?Sized = Reqwest> {
+pub struct Bot<Client = Reqwest> {
     /// Bot token, which is used to receive updates and send requests to the Telegram API
     pub token: String,
     /// Bot token, which is used in `Debug` implementation for privacy

--- a/telers/src/dispatcher.rs
+++ b/telers/src/dispatcher.rs
@@ -54,13 +54,13 @@
 
 use super::router::{PropagateEvent, Response};
 use crate::{
-    client::{Bot, Session},
+    client::{Bot, Reqwest, Session},
     context::Context,
     enums::UpdateType,
     errors::{EventErrorKind, HandlerError},
     methods::GetUpdates,
     types::Update,
-    Extensions, Request,
+    Extensions, Request, RouterConfigured,
 };
 
 use backoff::{backoff::Backoff, exponential::ExponentialBackoff, SystemClock};
@@ -82,7 +82,11 @@ pub const DEFAULT_POLLING_TIMEOUT: i64 = 30;
 
 /// Dispatcher using to dispatch incoming updates to the main router
 #[derive(Clone)]
-pub struct Dispatcher<Client, Propagator, BackoffType = ExponentialBackoff<SystemClock>> {
+pub struct Dispatcher<
+    Client = Reqwest,
+    Propagator = RouterConfigured,
+    BackoffType = ExponentialBackoff<SystemClock>,
+> {
     propagator: Propagator,
     bots: Vec<Bot<Client>>,
     extensions: Extensions,

--- a/telers/src/dispatcher.rs
+++ b/telers/src/dispatcher.rs
@@ -57,17 +57,22 @@ use crate::{
     client::{Bot, Session},
     context::Context,
     enums::UpdateType,
-    errors::EventErrorKind,
-    event::simple::HandlerResult as SimpleHandlerResult,
+    errors::{EventErrorKind, HandlerError},
     methods::GetUpdates,
     types::Update,
     Extensions, Request,
 };
 
 use backoff::{backoff::Backoff, exponential::ExponentialBackoff, SystemClock};
-use std::sync::Arc;
-use thiserror;
-use tokio::sync::mpsc::{channel as mspc_channel, error::SendError, Sender};
+use futures_util::future::BoxFuture;
+use std::{
+    future::{Future, IntoFuture},
+    sync::Arc,
+};
+use tokio::{
+    select,
+    sync::{mpsc, watch},
+};
 use tracing::{event, field, instrument, Level, Span};
 
 const GET_UPDATES_SIZE: i64 = 100;
@@ -75,22 +80,10 @@ const CHANNEL_UPDATES_SIZE: usize = 100;
 
 pub const DEFAULT_POLLING_TIMEOUT: i64 = 30;
 
-#[derive(Debug, thiserror::Error)]
-enum ListenerError<T> {
-    #[error(transparent)]
-    SendError(#[from] SendError<T>),
-}
-
-#[derive(Debug, thiserror::Error)]
-enum PollingError {
-    #[error("Polling was aborted by signal")]
-    Aborted,
-}
-
 /// Dispatcher using to dispatch incoming updates to the main router
 #[derive(Clone)]
 pub struct Dispatcher<Client, Propagator, BackoffType = ExponentialBackoff<SystemClock>> {
-    main_router: Propagator,
+    propagator: Propagator,
     bots: Vec<Bot<Client>>,
     extensions: Extensions,
     context: Context,
@@ -110,7 +103,7 @@ where
 }
 
 pub struct Builder<Client, Propagator, BackoffType = ExponentialBackoff<SystemClock>> {
-    main_router: Propagator,
+    propagator: Propagator,
     bots: Vec<Bot<Client>>,
     context: Context,
     extensions: Extensions,
@@ -127,7 +120,7 @@ where
     #[must_use]
     fn default() -> Self {
         Self {
-            main_router: Propagator::default(),
+            propagator: Propagator::default(),
             bots: vec![],
             context: Context::new(),
             extensions: Extensions::new(),
@@ -154,7 +147,7 @@ impl<Client, Propagator, BackoffType> Builder<Client, Propagator, BackoffType> {
         Propagator: PropagateEvent<Client>,
     {
         Self {
-            main_router: val,
+            propagator: val,
             ..self
         }
     }
@@ -279,7 +272,7 @@ impl<Client, Propagator, BackoffType> Builder<Client, Propagator, BackoffType> {
     #[must_use]
     pub fn build(self) -> Dispatcher<Client, Propagator, BackoffType> {
         Dispatcher {
-            main_router: self.main_router,
+            propagator: self.propagator,
             bots: self.bots,
             extensions: self.extensions,
             context: self.context,
@@ -290,7 +283,7 @@ impl<Client, Propagator, BackoffType> Builder<Client, Propagator, BackoffType> {
     }
 }
 
-impl<Client, PropagatorService, BackoffType> Dispatcher<Client, PropagatorService, BackoffType> {
+impl<Client, Propagator, BackoffType> Dispatcher<Client, Propagator, BackoffType> {
     /// Main entry point for incoming updates.
     /// This method will propagate update to the main router.
     #[instrument(skip_all, fields(update_id = update.id, update_type))]
@@ -301,13 +294,13 @@ impl<Client, PropagatorService, BackoffType> Dispatcher<Client, PropagatorServic
     ) -> Result<Response<Client>, EventErrorKind>
     where
         Client: Send + Sync + Clone + 'static,
-        PropagatorService: PropagateEvent<Client>,
+        Propagator: PropagateEvent<Client>,
     {
         let update_type = UpdateType::from(update.as_ref());
 
         Span::current().record("update_type", field::display(&update_type));
 
-        self.main_router
+        self.propagator
             .propagate_event(
                 update_type,
                 Request {
@@ -329,9 +322,9 @@ impl<Client, PropagatorService, BackoffType> Dispatcher<Client, PropagatorServic
         bot: Bot<Client>,
         polling_timeout: Option<i64>,
         allowed_updates: Vec<UpdateType>,
-        update_sender: Sender<Update>,
+        update_tx: mpsc::Sender<Update>,
         mut backoff: BackoffType,
-    ) -> Result<(), ListenerError<Update>>
+    ) -> mpsc::error::SendError<Update>
     where
         Client: Session,
         BackoffType: Backoff,
@@ -400,7 +393,9 @@ impl<Client, PropagatorService, BackoffType> Dispatcher<Client, PropagatorServic
             for update in updates {
                 event!(Level::TRACE, "Send update to the listener",);
 
-                update_sender.send(update).await?;
+                if let Err(err) = update_tx.send(update).await {
+                    return err;
+                }
             }
 
             // If we successfully connected to the server, we will reset backoff config
@@ -417,102 +412,60 @@ impl<Client, PropagatorService, BackoffType> Dispatcher<Client, PropagatorServic
 
     /// Internal polling process.
     /// Start listening updates for the bot and propagate them to the main router.
-    /// Wait exit signal to stop polling.
-    /// # Panics
-    /// If failed to register exit signal handlers
+    /// # Returns
+    /// Guard just should be dropped to stop polling
     #[instrument(skip_all, fields(bot_id = bot.id))]
-    async fn polling(&self, bot: Bot<Client>) -> PollingError
+    fn polling(&self, bot: Bot<Client>) -> impl Drop
     where
         Client: Session + Clone + 'static,
-        PropagatorService: PropagateEvent<Client> + Clone,
+        Propagator: PropagateEvent<Client> + Clone,
         BackoffType: Backoff + Send + Sync + Clone + 'static,
     {
-        let (sender_update, mut receiver_update) = mspc_channel(CHANNEL_UPDATES_SIZE);
+        let (signal_tx, signal_rx) = watch::channel(());
+        let (update_tx, mut update_rx) = mpsc::channel(CHANNEL_UPDATES_SIZE);
 
-        let listen_updates_handle = tokio::spawn(Self::listen_updates(
-            bot.clone(),
-            self.polling_timeout,
-            self.allowed_updates.clone(),
-            sender_update,
-            self.backoff.clone(),
-        ));
+        let hidden_token = bot.hidden_token.clone();
 
-        let receiver_updates_handle = tokio::spawn({
+        tokio::spawn({
+            let fut = Self::listen_updates(
+                bot.clone(),
+                self.polling_timeout,
+                self.allowed_updates.clone(),
+                update_tx,
+                self.backoff.clone(),
+            );
+
+            async move {
+                select! {
+                    _ = signal_tx.closed() => event!(Level::TRACE, "Select signal branch"),
+                    _ = fut => event!(Level::TRACE, "Select future branch"),
+                };
+                event!(Level::WARN, "Graceful shutdown signal received");
+            }
+        });
+        tokio::spawn({
             let dispatcher = self.clone();
 
             async move {
-                while let Some(update) = receiver_update.recv().await {
+                while let Some(update) = update_rx.recv().await {
                     event!(
                         Level::TRACE,
                         update_id = update.id,
                         "Received update from the listener"
                     );
 
+                    let update = Arc::new(update);
                     let bot = bot.clone();
                     let mut dispatcher = dispatcher.clone();
 
-                    tokio::spawn(
-                        async move { dispatcher.feed_update(bot, Arc::new(update)).await },
-                    );
+                    tokio::spawn(async move { dispatcher.feed_update(bot, update).await });
                 }
             }
         });
 
-        #[cfg(unix)]
-        {
-            use tokio::signal::unix::{signal, SignalKind};
+        event!(Level::INFO, token = hidden_token, "Started");
 
-            let mut sigint =
-                signal(SignalKind::interrupt()).expect("Failed to register SIGINT handler");
-            let mut sigterm =
-                signal(SignalKind::terminate()).expect("Failed to register SIGTERM handler");
-
-            tokio::select! {
-                _ = sigint.recv() => {
-                    event!(Level::WARN, "SIGINT signal received");
-                },
-                _ = sigterm.recv() => {
-                    event!(Level::WARN, "SIGTERM signal received");
-                },
-            }
-        }
-        #[cfg(windows)]
-        {
-            use tokio::signal::windows::{ctrl_break, ctrl_c};
-
-            let mut ctrl_c = ctrl_c().expect("Failed to register CTRL+C handler");
-            let mut ctrl_break = ctrl_break().expect("Failed to register CTRL+BREAK handler");
-
-            tokio::select! {
-                _ = ctrl_c.recv() => {
-                    event!(Level::WARN, "CTRL+C signal received");
-                },
-                _ = ctrl_break.recv() => {
-                    event!(Level::WARN,  "CTRL+BREAK signal received");
-                },
-            }
-        }
-
-        #[cfg(any(unix, windows))]
-        {
-            listen_updates_handle.abort();
-            receiver_updates_handle.abort();
-
-            PollingError::Aborted
-        }
-        #[cfg(not(any(unix, windows)))]
-        {
-            event!(
-                Level::WARN,
-                "Exit signals of this platform are not supported, \
-                so polling process will never stop by signal and shutdown events will never be emitted.",
-            );
-
-            listen_updates_handle.await;
-            receiver_updates_handle.await;
-
-            unimplemented!("Exit signals of this platform are not supported");
-        }
+        signal_rx
     }
 
     /// External polling process runner for multiple bots and emit startup and shutdown observers
@@ -522,88 +475,117 @@ impl<Client, PropagatorService, BackoffType> Dispatcher<Client, PropagatorServic
     /// # Panics
     /// - If failed to register exit signal handlers
     /// - If bots is empty
-    pub async fn run_polling(&mut self) -> Result<(), EventErrorKind>
+    pub fn run_polling(self) -> Serve<Client, Propagator, BackoffType>
     where
         Client: Session + Clone + 'static,
-        PropagatorService: PropagateEvent<Client> + 'static,
+        Propagator: PropagateEvent<Client> + 'static,
         BackoffType: Backoff + Send + Sync + Clone + 'static,
     {
-        event!(Level::TRACE, "Start emit startup observers");
-
-        if let Err(err) = self.main_router.emit_startup().await {
-            event!(Level::ERROR, error = %err, "Error while emit startup");
-            return Err(err.into());
-        }
-
-        self.run_polling_without_startup_and_shutdown().await;
-
-        event!(Level::TRACE, "Start emit shutdown observers");
-
-        self.emit_shutdown().await.map_err(|err| {
-            event!(Level::ERROR, error = %err, "Error while emit shutdown");
-            err.into()
-        })
-    }
-
-    /// External polling process runner for multiple bots
-    /// # Panics
-    /// If bots is empty
-    pub async fn run_polling_without_startup_and_shutdown(&mut self)
-    where
-        Client: Session + Clone + 'static,
-        PropagatorService: PropagateEvent<Client> + 'static,
-        BackoffType: Backoff + Send + Sync + Clone + 'static,
-    {
-        let bots_len = self.bots.len();
-
         assert!(
-            bots_len > 0,
+            self.bots.len() > 0,
             "You must add at least one bot to the dispatcher",
         );
 
-        let mut handles = Vec::with_capacity(bots_len);
-        for bot in self.bots.clone() {
-            event!(Level::INFO, bot = %bot, "Polling started");
+        Serve::new(self)
+    }
+}
 
-            let dispatcher = self.clone();
-            handles.push(tokio::spawn(async move { dispatcher.polling(bot).await }));
+pub struct Serve<Client, Propagator, BackoffType> {
+    dispatcher: Dispatcher<Client, Propagator, BackoffType>,
+}
+
+impl<Client, Propagator, BackoffType> Serve<Client, Propagator, BackoffType> {
+    pub const fn new(dispatcher: Dispatcher<Client, Propagator, BackoffType>) -> Self {
+        Self { dispatcher }
+    }
+
+    pub fn with_graceful_shutdown<Signal>(
+        self,
+        signal: Signal,
+    ) -> ServeWithGracefulShutdown<Client, Propagator, BackoffType, Signal>
+    where
+        Signal: Future + Send + 'static,
+        Signal::Output: Send,
+    {
+        ServeWithGracefulShutdown::new(self.dispatcher, signal)
+    }
+}
+
+impl<Client, Propagator, BackoffType> IntoFuture for Serve<Client, Propagator, BackoffType>
+where
+    Client: Session + Clone + 'static,
+    Propagator: PropagateEvent<Client>,
+    BackoffType: Backoff + Send + Sync + Clone + 'static,
+{
+    type Output = Result<(), HandlerError>;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
+
+    #[cfg(feature = "default_signal")]
+    fn into_future(self) -> Self::IntoFuture {
+        use crate::utils::shutdown_signal;
+
+        self.with_graceful_shutdown(shutdown_signal()).into_future()
+    }
+
+    #[cfg(not(feature = "default_signal"))]
+    fn into_future(self) -> Self::IntoFuture {
+        if self.dispatcher.propagator.shutdown_handlers_len() != 0 {
+            event!(
+                // I'm use target instead of name here because: https://github.com/tokio-rs/tracing/discussions/1587#discussioncomment-1370883
+                target: "telers:dispatcher:into_future",
+                Level::WARN,
+                "Shutdown observer can't be called without graceful shutdow. \
+                You can off this log by `telers:dispatcher:into_future=off`.",
+            );
         }
 
-        for handle in handles {
-            if let Err(err) = handle.await {
-                event!(Level::ERROR, error = %err);
+        self.with_graceful_shutdown(std::future::pending::<Self::Output>())
+            .into_future()
+    }
+}
+
+pub struct ServeWithGracefulShutdown<Client, Propagator, BackoffType, Signal> {
+    dispatcher: Dispatcher<Client, Propagator, BackoffType>,
+    signal: Signal,
+}
+
+impl<Client, Propagator, BackoffType, Signal>
+    ServeWithGracefulShutdown<Client, Propagator, BackoffType, Signal>
+{
+    pub const fn new(
+        dispatcher: Dispatcher<Client, Propagator, BackoffType>,
+        signal: Signal,
+    ) -> Self {
+        Self { dispatcher, signal }
+    }
+}
+
+impl<Client, Propagator, BackoffType, Signal> IntoFuture
+    for ServeWithGracefulShutdown<Client, Propagator, BackoffType, Signal>
+where
+    Client: Session + Clone + 'static,
+    Signal: Future + Send + 'static,
+    Signal::Output: Send,
+    Propagator: PropagateEvent<Client>,
+    BackoffType: Backoff + Send + Sync + Clone + 'static,
+{
+    type Output = Result<(), HandlerError>;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
+
+    fn into_future(mut self) -> Self::IntoFuture {
+        Box::pin(async move {
+            self.dispatcher.propagator.emit_startup().await?;
+
+            let mut pollings = Vec::with_capacity(self.dispatcher.bots.len());
+            for bot in self.dispatcher.bots.clone() {
+                pollings.push(self.dispatcher.polling(bot));
             }
-        }
 
-        event!(Level::WARN, "Polling finished");
-    }
+            self.signal.await;
 
-    /// Emit startup events.
-    /// Use this method if you want to emit startup events manually
-    /// # Notes
-    /// This method is called automatically in `run_polling` method,
-    /// but not in `run_polling_without_startup_and_shutdown` method
-    /// # Errors
-    /// If any startup observer returns error
-    pub async fn emit_startup(&mut self) -> SimpleHandlerResult
-    where
-        PropagatorService: PropagateEvent<Client>,
-    {
-        self.main_router.emit_startup().await
-    }
-
-    /// Emit shutdown events.
-    /// Use this method if you want to emit shutdown events manually
-    /// # Notes
-    /// This method is called automatically in `run_polling` method,
-    /// but not in `run_polling_without_startup_and_shutdown` method
-    /// # Errors
-    /// If any shutdown observer returns error
-    pub async fn emit_shutdown(&mut self) -> SimpleHandlerResult
-    where
-        PropagatorService: PropagateEvent<Client>,
-    {
-        self.main_router.emit_shutdown().await
+            self.dispatcher.propagator.emit_shutdown().await?;
+            Ok(())
+        })
     }
 }
 
@@ -630,7 +612,7 @@ mod tests {
             .build();
 
         let response = dispatcher
-            .feed_update(bot.clone(), Arc::clone(&update))
+            .feed_update(bot.clone(), update.clone())
             .await
             .unwrap();
 

--- a/telers/src/dispatcher.rs
+++ b/telers/src/dispatcher.rs
@@ -441,7 +441,7 @@ impl<Client, Propagator, BackoffType> Dispatcher<Client, Propagator, BackoffType
 
             async move {
                 select! {
-                    _ = signal_tx.closed() => event!(Level::TRACE, "Select signal branch"),
+                    () = signal_tx.closed() => event!(Level::TRACE, "Select signal branch"),
                     _ = fut => event!(Level::TRACE, "Select future branch"),
                 };
                 event!(Level::WARN, "Graceful shutdown signal received");
@@ -486,7 +486,7 @@ impl<Client, Propagator, BackoffType> Dispatcher<Client, Propagator, BackoffType
         BackoffType: Backoff + Send + Sync + Clone + 'static,
     {
         assert!(
-            self.bots.len() > 0,
+            !self.bots.is_empty(),
             "You must add at least one bot to the dispatcher",
         );
 

--- a/telers/src/event/simple/observer.rs
+++ b/telers/src/event/simple/observer.rs
@@ -77,6 +77,7 @@ impl Observer {
 }
 
 impl Observer {
+    #[allow(clippy::missing_errors_doc)]
     pub async fn trigger(&mut self, request: ()) -> HandlerResult {
         for handler in &mut self.handlers {
             handler.call(request).await?;

--- a/telers/src/event/simple/observer.rs
+++ b/telers/src/event/simple/observer.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 
 use std::fmt::{self, Debug, Formatter};
-use tracing::instrument;
 
 /// Simple events observer
 /// Is used for managing events isn't related with Telegram (For example startup/shutdown events)
@@ -78,13 +77,10 @@ impl Observer {
 }
 
 impl Observer {
-    #[allow(clippy::let_unit_value)]
-    #[instrument(skip(self, request))]
     pub async fn trigger(&mut self, request: ()) -> HandlerResult {
         for handler in &mut self.handlers {
             handler.call(request).await?;
         }
-
         Ok(())
     }
 }

--- a/telers/src/event/telegram/observer.rs
+++ b/telers/src/event/telegram/observer.rs
@@ -186,7 +186,7 @@ impl<Client> Observer<Client> {
     /// Handler will be called when all its filters is pass.
     /// # Errors
     /// - If any handler returns error. Probably it's error to extract args to the handler.
-    #[instrument(skip(self, request))]
+    #[instrument(skip_all)]
     pub async fn trigger(
         &mut self,
         request: Request<Client>,

--- a/telers/src/lib.rs
+++ b/telers/src/lib.rs
@@ -34,4 +34,4 @@ pub use extractor::Extractor;
 pub use filters::Filter;
 pub use fsm::Context as FSMContext;
 pub use request::Request;
-pub use router::Router;
+pub use router::{Configured as RouterConfigured, Router};

--- a/telers/src/router.rs
+++ b/telers/src/router.rs
@@ -185,10 +185,14 @@ pub trait PropagateEvent<Client>: Clone + Send + Sync + 'static {
     /// If any startup observer returns error
     async fn emit_startup(&mut self) -> SimpleHandlerResult;
 
+    fn starup_handlers_len(&self) -> usize;
+
     /// Emit shutdown events
     /// # Errors
     /// If any shutdown observer returns error
     async fn emit_shutdown(&mut self) -> SimpleHandlerResult;
+
+    fn shutdown_handlers_len(&self) -> usize;
 }
 
 /// Router combines all event observers.
@@ -939,26 +943,52 @@ where
 
     #[instrument(skip_all, fields(router = self.name))]
     async fn emit_startup(&mut self) -> SimpleHandlerResult {
+        if self.starup_handlers_len() == 0 {
+            event!(Level::TRACE, "Observers empty");
+            return Ok(());
+        }
+
+        event!(Level::DEBUG, "Start observers");
         for startup in once(&mut self.startup).chain(
             self.sub_routers
                 .iter_mut()
                 .map(|router| &mut router.startup),
         ) {
-            startup.trigger(()).await?;
+            if let Err(err) = startup.trigger(()).await {
+                event!(Level::ERROR, error = %err, "Error while emit observers");
+                return Err(err);
+            }
         }
         Ok(())
     }
 
+    fn starup_handlers_len(&self) -> usize {
+        self.startup.handlers().len()
+    }
+
     #[instrument(skip_all, fields(router = self.name))]
     async fn emit_shutdown(&mut self) -> SimpleHandlerResult {
+        if self.shutdown_handlers_len() == 0 {
+            event!(Level::TRACE, "Observers empty");
+            return Ok(());
+        }
+
+        event!(Level::DEBUG, "Start observers");
         for shutdown in once(&mut self.shutdown).chain(
             self.sub_routers
                 .iter_mut()
                 .map(|router| &mut router.shutdown),
         ) {
-            shutdown.trigger(()).await?;
+            if let Err(err) = shutdown.trigger(()).await {
+                event!(Level::ERROR, error = %err, "Error while emit observers");
+                return Err(err);
+            }
         }
         Ok(())
+    }
+
+    fn shutdown_handlers_len(&self) -> usize {
+        self.shutdown.handlers().len()
     }
 }
 

--- a/telers/src/router.rs
+++ b/telers/src/router.rs
@@ -94,6 +94,7 @@
 //! [`Router::include_router`]: Router#method.include_router
 
 use crate::{
+    client::Reqwest,
     enums::{SimpleObserverName, TelegramObserverName, UpdateType},
     errors::EventErrorKind,
     event::{
@@ -251,7 +252,7 @@ pub trait PropagateEvent<Client>: Clone + Send + Sync + 'static {
 /// router.message.register(on_message);
 /// router.callback_query.register(on_callback_query);
 /// ```
-pub struct Router<Client> {
+pub struct Router<Client = Reqwest> {
     name: &'static str,
     sub_routers: Vec<Router<Client>>,
 
@@ -697,7 +698,7 @@ impl<Client> Clone for Router<Client> {
     }
 }
 
-pub struct Configured<Client> {
+pub struct Configured<Client = Reqwest> {
     name: &'static str,
     sub_routers: Vec<Configured<Client>>,
 

--- a/telers/src/utils.rs
+++ b/telers/src/utils.rs
@@ -4,3 +4,9 @@ pub(crate) use error::format_error_report;
 
 pub mod text;
 pub mod token;
+
+#[cfg(feature = "signal")]
+pub mod signal;
+
+#[cfg(feature = "signal")]
+pub use signal::shutdown_signal;

--- a/telers/src/utils/signal.rs
+++ b/telers/src/utils/signal.rs
@@ -1,0 +1,25 @@
+use tokio::signal;
+
+pub async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}

--- a/telers/src/utils/signal.rs
+++ b/telers/src/utils/signal.rs
@@ -1,5 +1,7 @@
 use tokio::signal;
 
+/// # Panics
+/// Failed to install signal handler
 pub async fn shutdown_signal() {
     let ctrl_c = async {
         signal::ctrl_c()
@@ -19,7 +21,7 @@ pub async fn shutdown_signal() {
     let terminate = std::future::pending::<()>();
 
     tokio::select! {
-        _ = ctrl_c => {},
-        _ = terminate => {},
+        () = ctrl_c => {},
+        () = terminate => {},
     }
 }


### PR DESCRIPTION
Added:
- Possibility to register graceful shutdown signal using `with_graceful_shutdown`;
- New features `signal` (add signal realization to the framework) and `default_signal` (register signal realization automatically without use `with_graceful_shutdown(shutdown_signal())` manually).

Updated:
- Features of the framework in examples (added `default_signal`);
- Graceful shutdown for `axum` + `telers` (`axum_and_echo_bot`) example.