### PR TITLE
Update formatters generics

### DIFF
--- a/telers/src/utils/text/builder.rs
+++ b/telers/src/utils/text/builder.rs
@@ -62,7 +62,7 @@ where
             texts
                 .into_iter()
                 .map(|text| self.formatter.quote(text))
-                .collect::<Vec<_>>()
+                .collect::<Box<[_]>>()
                 .iter()
                 .map(String::as_str),
         );

--- a/telers/src/utils/text/builder.rs
+++ b/telers/src/utils/text/builder.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use super::{Formatter, FormatterErrorKind};
 
 use crate::types::{MessageEntity, User};
@@ -25,8 +27,8 @@ where
 
     /// Add text without formatting.
     #[must_use]
-    pub fn text(mut self, text: impl AsRef<str>) -> Self {
-        self.text.push_str(text.as_ref());
+    pub fn text(mut self, text: impl Display) -> Self {
+        self.text.push_str(text.to_string().as_ref());
         self
     }
 
@@ -34,16 +36,17 @@ where
     #[must_use]
     pub fn texts<T, I>(mut self, texts: I) -> Self
     where
-        I: AsRef<[T]>,
-        T: AsRef<str>,
+        String: Extend<T>,
+        I: IntoIterator<Item = T>,
+        T: Display,
     {
-        self.text.extend(texts.as_ref().iter().map(AsRef::as_ref));
+        self.text.extend(texts);
         self
     }
 
     /// Add quote text without formatting.
     #[must_use]
-    pub fn quote(mut self, text: impl AsRef<str>) -> Self {
+    pub fn quote(mut self, text: impl Display) -> Self {
         self.text.push_str(self.formatter.quote(text).as_str());
         self
     }
@@ -53,7 +56,7 @@ where
     pub fn quotes<T, I>(mut self, texts: I) -> Self
     where
         I: IntoIterator<Item = T>,
-        T: AsRef<str>,
+        T: Display,
     {
         self.text.extend(
             texts

--- a/telers/src/utils/text/formatter.rs
+++ b/telers/src/utils/text/formatter.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::types::{MessageEntity, MessageEntityKind};
 
 #[derive(Debug, thiserror::Error)]
@@ -24,75 +26,75 @@ pub trait Formatter {
     #[must_use]
     fn bold<T>(&self, text: T) -> String
     where
-        T: AsRef<str>;
+        T: Display;
 
     #[must_use]
     fn italic<T>(&self, text: T) -> String
     where
-        T: AsRef<str>;
+        T: Display;
 
     #[must_use]
     fn code<C>(&self, code: C) -> String
     where
-        C: AsRef<str>;
+        C: Display;
 
     #[must_use]
     fn underline<T>(&self, text: T) -> String
     where
-        T: AsRef<str>;
+        T: Display;
 
     #[must_use]
     fn strikethrough<T>(&self, text: T) -> String
     where
-        T: AsRef<str>;
+        T: Display;
 
     #[must_use]
     fn spoiler<T>(&self, text: T) -> String
     where
-        T: AsRef<str>;
+        T: Display;
 
     #[must_use]
     fn blockquote<T>(&self, text: T) -> String
     where
-        T: AsRef<str>;
+        T: Display;
 
     #[must_use]
     fn expandable_blockquote<T>(&self, text: T) -> String
     where
-        T: AsRef<str>;
+        T: Display;
 
     #[must_use]
     fn text_link<T, U>(&self, text: T, url: U) -> String
     where
-        T: AsRef<str>,
-        U: AsRef<str>;
+        T: Display,
+        U: Display;
 
     #[must_use]
     fn text_mention<T>(&self, text: T, user_id: i64) -> String
     where
-        T: AsRef<str>;
+        T: Display;
 
     #[must_use]
     fn custom_emoji<T, E>(&self, emoji: T, emoji_id: E) -> String
     where
-        T: AsRef<str>,
-        E: AsRef<str>;
+        T: Display,
+        E: Display;
 
     #[must_use]
     fn pre<C>(&self, code: C) -> String
     where
-        C: AsRef<str>;
+        C: Display;
 
     #[must_use]
     fn pre_language<C, L>(&self, code: C, language: L) -> String
     where
-        C: AsRef<str>,
-        L: AsRef<str>;
+        C: Display,
+        L: Display;
 
     #[must_use]
     fn quote<T>(&self, text: T) -> String
     where
-        T: AsRef<str>;
+        T: Display;
 
     /// Apply the [`MessageEntity`] to the given text with offset and length.
     /// # Notes
@@ -104,7 +106,7 @@ pub trait Formatter {
     /// - If the given entity offset+length is out of bounds, then the [`ErrorKind::IndexOutOfBounds`] will be returned.
     fn apply_entity<T>(&self, text: T, entity: &MessageEntity) -> Result<String, ErrorKind>
     where
-        T: AsRef<str>;
+        T: Display;
 
     /// Apply the [`MessageEntityKind`] to the whole given text.
     /// # Notes
@@ -123,9 +125,9 @@ pub trait Formatter {
         entity_kind: MessageEntityKind,
     ) -> Result<String, ErrorKind>
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        let text = text.as_ref();
+        let text = text.to_string();
         let text_len = text.len();
 
         if text_len == 0 {
@@ -148,18 +150,16 @@ mod tests {
     impl Formatter for TestFormatter {
         fn bold<T>(&self, text: T) -> String
         where
-            T: AsRef<str>,
+            T: Display,
         {
-            let text = text.as_ref();
-
             format!("**{text}**")
         }
 
         fn apply_entity<T>(&self, text: T, entity: &MessageEntity) -> Result<String, ErrorKind>
         where
-            T: AsRef<str>,
+            T: Display,
         {
-            let text = text.as_ref();
+            let text = text.to_string();
             let text_len = text.len();
 
             if text_len == 0 {
@@ -188,94 +188,94 @@ mod tests {
 
         fn italic<T>(&self, _text: T) -> String
         where
-            T: AsRef<str>,
+            T: Display,
         {
             todo!()
         }
 
         fn code<C>(&self, _code: C) -> String
         where
-            C: AsRef<str>,
+            C: Display,
         {
             todo!()
         }
 
         fn underline<T>(&self, _text: T) -> String
         where
-            T: AsRef<str>,
+            T: Display,
         {
             todo!()
         }
 
         fn strikethrough<T>(&self, _text: T) -> String
         where
-            T: AsRef<str>,
+            T: Display,
         {
             todo!()
         }
 
         fn spoiler<T>(&self, _text: T) -> String
         where
-            T: AsRef<str>,
+            T: Display,
         {
             todo!()
         }
 
         fn blockquote<T>(&self, _text: T) -> String
         where
-            T: AsRef<str>,
+            T: Display,
         {
             todo!()
         }
 
         fn expandable_blockquote<T>(&self, _text: T) -> String
         where
-            T: AsRef<str>,
+            T: Display,
         {
             todo!()
         }
 
         fn text_link<T, U>(&self, _text: T, _url: U) -> String
         where
-            T: AsRef<str>,
-            U: AsRef<str>,
+            T: Display,
+            U: Display,
         {
             todo!()
         }
 
         fn text_mention<T>(&self, _text: T, _user_id: i64) -> String
         where
-            T: AsRef<str>,
+            T: Display,
         {
             todo!()
         }
 
         fn custom_emoji<T, E>(&self, _emoji: T, _emoji_id: E) -> String
         where
-            T: AsRef<str>,
-            E: AsRef<str>,
+            T: Display,
+            E: Display,
         {
             todo!()
         }
 
         fn pre<C>(&self, _code: C) -> String
         where
-            C: AsRef<str>,
+            C: Display,
         {
             todo!()
         }
 
         fn pre_language<C, L>(&self, _code: C, _language: L) -> String
         where
-            C: AsRef<str>,
-            L: AsRef<str>,
+            C: Display,
+            L: Display,
         {
             todo!()
         }
 
         fn quote<T>(&self, _text: T) -> String
         where
-            T: AsRef<str>,
+            T: Display,
         {
             todo!()
         }

--- a/telers/src/utils/text/html_formatter.rs
+++ b/telers/src/utils/text/html_formatter.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use super::{Formatter as TextFormatter, FormatterErrorKind};
 
 use crate::types::{
@@ -65,7 +67,6 @@ impl Formatter {
 }
 
 impl Default for Formatter {
-    #[must_use]
     fn default() -> Self {
         Self::new()
     }
@@ -74,142 +75,106 @@ impl Default for Formatter {
 impl TextFormatter for Formatter {
     fn bold<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!(
-            "<{tag}>{text}</{tag}>",
-            text = text.as_ref(),
-            tag = self.bold_tag
-        )
+        format!("<{tag}>{text}</{tag}>", tag = self.bold_tag)
     }
 
     fn italic<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!(
-            "<{tag}>{text}</{tag}>",
-            text = text.as_ref(),
-            tag = self.italic_tag
-        )
+        format!("<{tag}>{text}</{tag}>", tag = self.italic_tag)
     }
 
     fn underline<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!(
-            "<{tag}>{text}</{tag}>",
-            text = text.as_ref(),
-            tag = self.underline_tag
-        )
+        format!("<{tag}>{text}</{tag}>", tag = self.underline_tag)
     }
 
     fn strikethrough<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!(
-            "<{tag}>{text}</{tag}>",
-            text = text.as_ref(),
-            tag = self.strikethrough_tag
-        )
+        format!("<{tag}>{text}</{tag}>", tag = self.strikethrough_tag)
     }
 
     fn spoiler<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!(
-            "<{tag}>{text}</{tag}>",
-            text = text.as_ref(),
-            tag = self.spoiler_tag
-        )
+        format!("<{tag}>{text}</{tag}>", tag = self.spoiler_tag)
     }
 
     fn blockquote<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!("<blockquote>{text}</blockquote>", text = text.as_ref())
+        format!("<blockquote>{text}</blockquote>")
     }
 
     fn expandable_blockquote<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!(
-            "<blockquote expandable>{text}</blockquote>",
-            text = text.as_ref()
-        )
+        format!("<blockquote expandable>{text}</blockquote>")
     }
 
     fn text_link<T, U>(&self, text: T, url: U) -> String
     where
-        T: AsRef<str>,
-        U: AsRef<str>,
+        T: Display,
+        U: Display,
     {
-        format!(
-            "<a href=\"{url}\">{text}</a>",
-            url = url.as_ref(),
-            text = text.as_ref()
-        )
+        format!("<a href=\"{url}\">{text}</a>")
     }
 
     fn text_mention<T>(&self, text: T, user_id: i64) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!(
-            "<a href=\"tg://user?id={user_id}\">{text}</a>",
-            text = text.as_ref()
-        )
+        format!("<a href=\"tg://user?id={user_id}\">{text}</a>")
     }
 
     fn custom_emoji<T, E>(&self, text: T, emoji_id: E) -> String
     where
-        T: AsRef<str>,
-        E: AsRef<str>,
+        T: Display,
+        E: Display,
     {
         format!(
             "<{tag} data-emoji-id=\"{emoji_id}\">{text}</{tag}>",
-            text = text.as_ref(),
-            emoji_id = emoji_id.as_ref(),
             tag = self.emoji_tag,
         )
     }
 
     fn code<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!("<code>{text}</code>", text = text.as_ref())
+        format!("<code>{text}</code>")
     }
 
     fn pre<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!("<pre>{text}</pre>", text = text.as_ref())
+        format!("<pre>{text}</pre>")
     }
 
     fn pre_language<T, L>(&self, text: T, language: L) -> String
     where
-        T: AsRef<str>,
-        L: AsRef<str>,
+        T: Display,
+        L: Display,
     {
-        format!(
-            "<pre><code class=\"language-{language}\">{text}</code></pre>",
-            text = text.as_ref(),
-            language = language.as_ref()
-        )
+        format!("<pre><code class=\"language-{language}\">{text}</code></pre>")
     }
 
     fn quote<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        let text = text.as_ref();
+        let text = text.to_string();
 
         text.chars()
             .fold(String::with_capacity(text.len()), |mut string, ch| {
@@ -225,9 +190,9 @@ impl TextFormatter for Formatter {
 
     fn apply_entity<T>(&self, text: T, entity: &MessageEntity) -> Result<String, FormatterErrorKind>
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        let text = text.as_ref();
+        let text = text.to_string();
         let text_len = text.len();
 
         if text_len == 0 {
@@ -291,59 +256,59 @@ impl TextFormatter for Formatter {
 
 pub const FORMATTER: Formatter = Formatter::new();
 
-pub fn bold(text: impl AsRef<str>) -> String {
+pub fn bold(text: impl Display) -> String {
     FORMATTER.bold(text)
 }
 
-pub fn italic(text: impl AsRef<str>) -> String {
+pub fn italic(text: impl Display) -> String {
     FORMATTER.italic(text)
 }
 
-pub fn underline(text: impl AsRef<str>) -> String {
+pub fn underline(text: impl Display) -> String {
     FORMATTER.underline(text)
 }
 
-pub fn strikethrough(text: impl AsRef<str>) -> String {
+pub fn strikethrough(text: impl Display) -> String {
     FORMATTER.strikethrough(text)
 }
 
-pub fn spoiler(text: impl AsRef<str>) -> String {
+pub fn spoiler(text: impl Display) -> String {
     FORMATTER.spoiler(text)
 }
 
-pub fn blockquote(text: impl AsRef<str>) -> String {
+pub fn blockquote(text: impl Display) -> String {
     FORMATTER.blockquote(text)
 }
 
-pub fn expandable_blockquote(text: impl AsRef<str>) -> String {
+pub fn expandable_blockquote(text: impl Display) -> String {
     FORMATTER.expandable_blockquote(text)
 }
 
-pub fn text_link(text: impl AsRef<str>, url: impl AsRef<str>) -> String {
+pub fn text_link(text: impl Display, url: impl Display) -> String {
     FORMATTER.text_link(text, url)
 }
 
-pub fn text_mention(text: impl AsRef<str>, user_id: i64) -> String {
+pub fn text_mention(text: impl Display, user_id: i64) -> String {
     FORMATTER.text_mention(text, user_id)
 }
 
-pub fn custom_emoji(text: impl AsRef<str>, emoji_id: impl AsRef<str>) -> String {
+pub fn custom_emoji(text: impl Display, emoji_id: impl Display) -> String {
     FORMATTER.custom_emoji(text, emoji_id)
 }
 
-pub fn code(text: impl AsRef<str>) -> String {
+pub fn code(text: impl Display) -> String {
     FORMATTER.code(text)
 }
 
-pub fn pre(text: impl AsRef<str>) -> String {
+pub fn pre(text: impl Display) -> String {
     FORMATTER.pre(text)
 }
 
-pub fn pre_language(text: impl AsRef<str>, language: impl AsRef<str>) -> String {
+pub fn pre_language(text: impl Display, language: impl Display) -> String {
     FORMATTER.pre_language(text, language)
 }
 
-pub fn quote(text: impl AsRef<str>) -> String {
+pub fn quote(text: impl Display) -> String {
     FORMATTER.quote(text)
 }
 

--- a/telers/src/utils/text/markdown_formatter.rs
+++ b/telers/src/utils/text/markdown_formatter.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use super::{Formatter as TextFormatter, FormatterErrorKind};
 
 use crate::types::{
@@ -26,7 +28,6 @@ impl Formatter {
 }
 
 impl Default for Formatter {
-    #[must_use]
     fn default() -> Self {
         Self::new()
     }
@@ -35,44 +36,44 @@ impl Default for Formatter {
 impl TextFormatter for Formatter {
     fn bold<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!("*{text}*", text = text.as_ref())
+        format!("*{text}*")
     }
 
     fn italic<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!("_\r{text}_\r", text = text.as_ref())
+        format!("_\r{text}_\r")
     }
 
     fn underline<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!("__\r{text}__\r", text = text.as_ref())
+        format!("__\r{text}__\r")
     }
 
     fn strikethrough<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!("~{text}~", text = text.as_ref())
+        format!("~{text}~")
     }
 
     fn spoiler<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!("|{text}|", text = text.as_ref())
+        format!("|{text}|")
     }
 
     fn blockquote<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        text.as_ref()
+        text.to_string()
             .lines()
             .map(|line| format!(">{line}"))
             .collect::<Vec<_>>()
@@ -81,7 +82,7 @@ impl TextFormatter for Formatter {
 
     fn expandable_blockquote<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
         let mut text = self.blockquote(text);
         text.push_str("||");
@@ -91,64 +92,57 @@ impl TextFormatter for Formatter {
 
     fn text_link<T, U>(&self, text: T, url: U) -> String
     where
-        T: AsRef<str>,
-        U: AsRef<str>,
+        T: Display,
+        U: Display,
     {
-        format!("[{text}]({url})", text = text.as_ref(), url = url.as_ref())
+        format!("[{text}]({url})")
     }
 
     fn text_mention<T>(&self, text: T, user_id: i64) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
         self.text_link(text, format!("tg://user?id={user_id}"))
     }
 
     fn custom_emoji<T, E>(&self, emoji: T, emoji_id: E) -> String
     where
-        T: AsRef<str>,
-        E: AsRef<str>,
+        T: Display,
+        E: Display,
     {
         format!(
             "!{}",
-            self.text_link(
-                emoji,
-                format!("tg://emoji?id={emoji_id}", emoji_id = emoji_id.as_ref()),
-            )
+            self.text_link(emoji, format!("tg://emoji?id={emoji_id}"),)
         )
     }
 
     fn code<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!("`{text}`", text = text.as_ref())
+        format!("`{text}`")
     }
 
     fn pre<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        format!("```\n{text}\n```", text = text.as_ref())
+        format!("```\n{text}\n```")
     }
 
     fn pre_language<T, L>(&self, text: T, language: L) -> String
     where
-        T: AsRef<str>,
-        L: AsRef<str>,
+        T: Display,
+        L: Display,
     {
-        format!(
-            "```{language}\n{text}\n```",
-            language = language.as_ref(),
-            text = text.as_ref()
-        )
+        format!("```{language}\n{text}\n```")
     }
 
     fn quote<T>(&self, text: T) -> String
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        let text = text.as_ref();
+        let text = text.to_string();
 
         text.chars()
             .fold(String::with_capacity(text.len()), |mut string, ch| {
@@ -162,9 +156,9 @@ impl TextFormatter for Formatter {
 
     fn apply_entity<T>(&self, text: T, entity: &MessageEntity) -> Result<String, FormatterErrorKind>
     where
-        T: AsRef<str>,
+        T: Display,
     {
-        let text = text.as_ref();
+        let text = text.to_string();
         let text_len = text.len();
 
         if text_len == 0 {
@@ -228,59 +222,59 @@ impl TextFormatter for Formatter {
 
 pub const FORMATTER: Formatter = Formatter::new();
 
-pub fn bold(text: impl AsRef<str>) -> String {
+pub fn bold(text: impl Display) -> String {
     FORMATTER.bold(text)
 }
 
-pub fn italic(text: impl AsRef<str>) -> String {
+pub fn italic(text: impl Display) -> String {
     FORMATTER.italic(text)
 }
 
-pub fn underline(text: impl AsRef<str>) -> String {
+pub fn underline(text: impl Display) -> String {
     FORMATTER.underline(text)
 }
 
-pub fn strikethrough(text: impl AsRef<str>) -> String {
+pub fn strikethrough(text: impl Display) -> String {
     FORMATTER.strikethrough(text)
 }
 
-pub fn spoiler(text: impl AsRef<str>) -> String {
+pub fn spoiler(text: impl Display) -> String {
     FORMATTER.spoiler(text)
 }
 
-pub fn blockquote(text: impl AsRef<str>) -> String {
+pub fn blockquote(text: impl Display) -> String {
     FORMATTER.blockquote(text)
 }
 
-pub fn expandable_blockquote(text: impl AsRef<str>) -> String {
+pub fn expandable_blockquote(text: impl Display) -> String {
     FORMATTER.expandable_blockquote(text)
 }
 
-pub fn text_link(text: impl AsRef<str>, url: &str) -> String {
+pub fn text_link(text: impl Display, url: &str) -> String {
     FORMATTER.text_link(text, url)
 }
 
-pub fn text_mention(text: impl AsRef<str>, user_id: i64) -> String {
+pub fn text_mention(text: impl Display, user_id: i64) -> String {
     FORMATTER.text_mention(text, user_id)
 }
 
-pub fn custom_emoji(text: impl AsRef<str>, emoji_id: &str) -> String {
+pub fn custom_emoji(text: impl Display, emoji_id: &str) -> String {
     FORMATTER.custom_emoji(text, emoji_id)
 }
 
-pub fn code(text: impl AsRef<str>) -> String {
+pub fn code(text: impl Display) -> String {
     FORMATTER.code(text)
 }
 
-pub fn pre(text: impl AsRef<str>) -> String {
+pub fn pre(text: impl Display) -> String {
     FORMATTER.pre(text)
 }
 
-pub fn pre_language(text: impl AsRef<str>, language: &str) -> String {
+pub fn pre_language(text: impl Display, language: &str) -> String {
     FORMATTER.pre_language(text, language)
 }
 
-pub fn quote(text: impl AsRef<str>) -> String {
+pub fn quote(text: impl Display) -> String {
     FORMATTER.quote(text)
 }
 


### PR DESCRIPTION
Previously, it was impossible to pass numbers, for example, as arguments; we had to manually convert them to a string.
```Rust
let number = 123;
let result = html_code(number.to_string());
```
Now formatters can receive all types that implement `Display` trait, and we don't need to convert it before passing.