### PR TITLE
Simplify examples: use Bot::from_env() and clean up tracing boilerplate

### DIFF
--- a/examples/axum_and_echo_bot/src/main.rs
+++ b/examples/axum_and_echo_bot/src/main.rs
@@ -1,8 +1,8 @@
 //! This example shows how to create an echo bot and how to run it concurrently with polling `axum` server.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package axum_and_echo_bot
+//! BOT_TOKEN={your_bot_token} cargo run --package axum_and_echo_bot
 //! ```
 
 use axum::{routing, Router as AxumRouter};
@@ -21,7 +21,6 @@ use tokio::{
     net::TcpListener,
     sync::broadcast::{channel, Receiver, Sender},
 };
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 const SERVER_HOST: &str = "0.0.0.0";
 const SERVER_PORT: u16 = 3000;
@@ -37,19 +36,15 @@ async fn echo_handler(bot: Bot, message: Message) -> HandlerResult {
     Ok(EventReturn::Finish)
 }
 
-#[allow(clippy::unused_async)]
 async fn hello_world_handler() -> &'static str {
     "Hello, World!"
 }
 
-#[tokio::main(flavor = "multi_thread")]
+#[tokio::main]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = TelersRouter::new("main");
     router.message.register(Handler::new(echo_handler));
@@ -75,6 +70,7 @@ async fn run_server(app: AxumRouter, mut shutdown_rx: Receiver<()>) {
     let listener = TcpListener::bind(format!("{SERVER_HOST}:{SERVER_PORT}"))
         .await
         .unwrap();
+
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             let _ = shutdown_rx.recv().await;

--- a/examples/axum_webhook/src/main.rs
+++ b/examples/axum_webhook/src/main.rs
@@ -1,8 +1,8 @@
 //! This example shows how to setup webhooks for a bot using `axum` server.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package axum_webhook
+//! BOT_TOKEN={your_bot_token} cargo run --package axum_webhook
 //! ```
 
 use std::fmt::Display;
@@ -25,7 +25,6 @@ use tokio::{
     net::TcpListener,
     sync::broadcast::{channel, Receiver, Sender},
 };
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 const SERVER_HOST: &str = "0.0.0.0";
 const SERVER_PORT: u16 = 3000;
@@ -63,14 +62,12 @@ async fn set_webhook(
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = TelersRouter::new("main");
+
     router
         .message
         .register(telegram::Handler::new(echo_handler));
@@ -103,6 +100,7 @@ async fn run_server(app: AxumRouter, mut shutdown_rx: Receiver<()>) {
     let listener = TcpListener::bind(format!("{SERVER_HOST}:{SERVER_PORT}"))
         .await
         .unwrap();
+
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             let _ = shutdown_rx.recv().await;

--- a/examples/bot_http_client/src/main.rs
+++ b/examples/bot_http_client/src/main.rs
@@ -16,9 +16,9 @@
 //! }
 //! ```
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package bot_http_client
+//! BOT_TOKEN={your_bot_token} cargo run --package bot_http_client
 //! ```
 //!
 //! [`Bot::with_client`]: telers::Bot#method.with_client
@@ -35,8 +35,6 @@ use telers::{
     types::Message,
     Bot, Dispatcher, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 #[derive(Clone)]
 struct CustomClient {
@@ -87,10 +85,7 @@ async fn echo_handler(bot: Bot<impl Session>, message: Message) -> HandlerResult
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
     let token = std::env::var("BOT_TOKEN").expect("BOT_TOKEN env variable is not set!");
     let bot = Bot::with_client(token, CustomClient::default());
@@ -105,7 +100,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/business_connection/src/main.rs
+++ b/examples/business_connection/src/main.rs
@@ -1,8 +1,8 @@
 //! This example shows how to receive updates from business connections.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package business_connection
+//! BOT_TOKEN={your_bot_token} cargo run --package business_connection
 //! ```
 
 use telers::{
@@ -14,21 +14,15 @@ use telers::{
     types::{BusinessConnection, BusinessMessagesDeleted, Message},
     Bot, Dispatcher, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 async fn connection(business_connection: BusinessConnection) -> HandlerResult {
-    event!(
-        Level::DEBUG,
-        ?business_connection,
-        "Received business connection",
-    );
+    tracing::debug!(?business_connection, "Received business connection");
 
     Ok(EventReturn::Finish)
 }
 
 async fn message(bot: Bot, message: Message) -> HandlerResult {
-    event!(Level::DEBUG, ?message, "Received message");
+    tracing::debug!(?message, "Received message");
 
     bot.send(
         SendMessage::new(message.chat().id(), "Hello world!")
@@ -40,34 +34,34 @@ async fn message(bot: Bot, message: Message) -> HandlerResult {
 }
 
 async fn message_edited(message: Message) -> HandlerResult {
-    event!(Level::DEBUG, ?message, "Received edited message");
+    tracing::debug!(?message, "Received edited message");
 
     Ok(EventReturn::Finish)
 }
 
 async fn messages_deleted(messages_deleted: BusinessMessagesDeleted) -> HandlerResult {
-    event!(Level::DEBUG, ?messages_deleted, "Received deleted messages");
+    tracing::debug!(?messages_deleted, "Received deleted messages");
 
     Ok(EventReturn::Finish)
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = Router::new("main");
     router
         .business_connection
         .register(Handler::new(connection));
+
     router.business_message.register(Handler::new(message));
+
     router
         .edited_business_message
         .register(Handler::new(message_edited));
+
     router
         .deleted_business_messages
         .register(Handler::new(messages_deleted));
@@ -79,7 +73,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/context/src/main.rs
+++ b/examples/context/src/main.rs
@@ -1,9 +1,9 @@
 //! This example shows how to use [`Context`] to save data and use it in handlers.
 //! Check out the documentation of the [`context module`] for more information.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package context
+//! BOT_TOKEN={your_bot_token} cargo run --package context
 //! ```
 //!
 //! [`Context`]: telers::Context
@@ -22,8 +22,6 @@ use telers::{
     types::Message,
     Bot, Context, Dispatcher, FromContext, Request, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 // We use `FromContext` here to implement `Extractor` for `Data` which extract it to handler arguments automatically.
 // Check `extractor` module for more information.
@@ -64,12 +62,9 @@ async fn send_data_handler(
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = Router::new("main");
 
@@ -92,7 +87,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/echo_bot/src/main.rs
+++ b/examples/echo_bot/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package echo_bot
+//! BOT_TOKEN={your_bot_token} cargo run --package echo_bot
 //! ```
 
 use telers::{
@@ -15,8 +15,6 @@ use telers::{
     types::Message,
     Bot, Dispatcher, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 async fn echo_handler(bot: Bot, message: Message) -> HandlerResult {
     bot.send(CopyMessage::new(
@@ -31,12 +29,9 @@ async fn echo_handler(bot: Bot, message: Message) -> HandlerResult {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = Router::new("main");
     router.message.register(Handler::new(echo_handler));
@@ -48,7 +43,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!( error = %err, "Bot stopped"),
     }
 }

--- a/examples/extensions/src/main.rs
+++ b/examples/extensions/src/main.rs
@@ -1,9 +1,9 @@
 //! This example shows how to use [`Extensions`] to save data and use it in handlers as [`Extension`].
 //! Check out the documentation of the [`extensions module`] for more information.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package extensions
+//! BOT_TOKEN={your_bot_token} cargo run --package extensions
 //! ```
 //!
 //! [`Extension`]: telers::Extension
@@ -24,8 +24,6 @@ use telers::{
     types::Message,
     Bot, Dispatcher, Extension, Extensions, Request, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NumData(i64);
@@ -73,12 +71,9 @@ async fn send_data_handler(
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = Router::new("main");
 
@@ -102,7 +97,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/extractor/src/main.rs
+++ b/examples/extractor/src/main.rs
@@ -1,9 +1,9 @@
 //! This example shows how to use [`Extractor`] to extract data and use it in handlers.
 //! Check out the documentation of the [`extractor module`] for more information
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package extractor
+//! BOT_TOKEN={your_bot_token} cargo run --package extractor
 //! ```
 //!
 //! [`Extractor`]: telers::Extractor
@@ -24,8 +24,6 @@ use telers::{
     types::{Message, Update},
     Bot, Context, Dispatcher, Extension, Extractor, FromContext, FromEvent, Request, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 /// Implementing [`Extractor`] by [`FromEvent`] macros to use struct in handlers.
 /// # Notes
@@ -54,9 +52,8 @@ impl From<Update> for UpdateId {
 struct UpdateChatId(i64);
 
 impl TryFrom<Update> for UpdateChatId {
-    type Error = ConvertToTypeError;
-
     // You can use your own error type here
+    type Error = ConvertToTypeError;
 
     fn try_from(update: Update) -> Result<Self, Self::Error> {
         match update.chat() {
@@ -77,7 +74,7 @@ async fn update_id_handler(
                 .await?;
         }
         None => {
-            event!(Level::WARN, "Update doesn't contain chat id");
+            tracing::warn!("Update doesn't contain chat id");
         }
     }
 
@@ -150,12 +147,9 @@ async fn send_data_handler(
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = Router::new("main");
 
@@ -179,7 +173,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/fsm/src/main.rs
+++ b/examples/fsm/src/main.rs
@@ -12,9 +12,9 @@
 //!
 //! More information about FSM you can find in [`telers::fsm`] and [`FSMContextMiddleware`] documentation.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package fsm
+//! BOT_TOKEN={your_bot_token} cargo run --package fsm
 //! ```
 
 use telers::{
@@ -24,14 +24,15 @@ use telers::{
         EventReturn,
     },
     filters::{Command, MessageType, State as StateFilter},
-    fsm::{Context as FSMContext, MemoryStorage, Storage, Strategy::UserInChat},
+    fsm::{Context as FSMContext, MemoryStorage, Strategy::UserInChat},
     methods::SendMessage,
     middlewares::outer::FSMContext as FSMContextMiddleware,
     types::{Message, MessageText},
     Bot, Dispatcher, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
+
+/// Shorthand for the FSM context with in-memory storage. Replace `MemoryStorage` with your own `Storage` impl if needed.
+type FSM = FSMContext<MemoryStorage>;
 
 /// State of conversation.
 ///
@@ -61,11 +62,7 @@ impl PartialEq<&str> for State {
     }
 }
 
-async fn start_handler<S: Storage>(
-    bot: Bot,
-    message: Message,
-    fsm: FSMContext<S>,
-) -> HandlerResult {
+async fn start_handler(bot: Bot, message: Message, fsm: FSM) -> HandlerResult {
     bot.send(SendMessage::new(
         message.chat().id(),
         "Hello! What's your name?",
@@ -75,24 +72,18 @@ async fn start_handler<S: Storage>(
     // We set state to `State::Name` to point that we are waiting for user's name.
     // `name_handler` will be called when user will send message,
     // because we set `State::Name` as state and this handler is registered for this state
-    fsm.set_state(State::Name).await.map_err(Into::into)?;
+    fsm.set_state(State::Name).await?;
 
     Ok(EventReturn::Finish)
 }
 
-async fn name_handler<S: Storage>(
-    bot: Bot,
-    message: MessageText,
-    fsm: FSMContext<S>,
-) -> HandlerResult {
+async fn name_handler(bot: Bot, message: MessageText, fsm: FSM) -> HandlerResult {
     let name = message.text;
 
     // Save name to FSM storage, because we will need it in `language_handler`
-    fsm.set_value("name", name.clone())
-        .await
-        .map_err(Into::into)?;
+    fsm.set_value("name", name.clone()).await?;
     // Set state to `State::Language` to point that we are waiting for user's language
-    fsm.set_state(State::Language).await.map_err(Into::into)?;
+    fsm.set_state(State::Language).await?;
 
     // Usually state and data set to FSM storage before sending message to user,
     // because we want to be sure that we will receive message from user in the same state
@@ -107,20 +98,12 @@ async fn name_handler<S: Storage>(
     Ok(EventReturn::Finish)
 }
 
-async fn language_handler<S: Storage>(
-    bot: Bot,
-    message: MessageText,
-    fsm: FSMContext<S>,
-) -> HandlerResult {
+async fn language_handler(bot: Bot, message: MessageText, fsm: FSM) -> HandlerResult {
     let language = message.text;
 
     // Get user's name from FSM storage
     // TODO: Add validation, e.g. check that name isn't empty
-    let name: Box<str> = fsm
-        .get_value("name")
-        .await
-        .map_err(Into::into)?
-        .expect("Name should be set");
+    let name: Box<str> = fsm.get_value("name").await?.expect("Name should be set");
 
     // Check if user's language is acceptable
     match language.to_lowercase().as_str() {
@@ -132,7 +115,7 @@ async fn language_handler<S: Storage>(
             .await?;
 
             // Remove state and data from FSM storage, because we don't need them anymore
-            fsm.finish().await.map_err(Into::into)?;
+            fsm.finish().await?;
         }
         _ => {
             bot.send(SendMessage::new(
@@ -142,7 +125,7 @@ async fn language_handler<S: Storage>(
             .await?;
 
             // We don't need this, because `State::Language` is already set and doesn't change automatically
-            // fsm.set_state(State::Language).await.map_err(Into::into)?;
+            // fsm.set_state(State::Language).await?;
         }
     }
 
@@ -151,12 +134,9 @@ async fn language_handler<S: Storage>(
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     // You can use any storage, which implements `Storage` trait
     let storage = MemoryStorage::new();
@@ -170,13 +150,13 @@ async fn main() {
         .register(FSMContextMiddleware::new(storage).strategy(UserInChat));
 
     router.message.registers([
-        Handler::new(start_handler::<MemoryStorage>)
+        Handler::new(start_handler)
             .filter(Command::one("start"))
             .filter(StateFilter::none()),
-        Handler::new(name_handler::<MemoryStorage>)
+        Handler::new(name_handler)
             .filter(MessageType::one(Text))
             .filter(StateFilter::one(State::Name)),
-        Handler::new(language_handler::<MemoryStorage>)
+        Handler::new(language_handler)
             .filter(MessageType::one(Text))
             .filter(StateFilter::one(State::Language)),
     ]);
@@ -188,7 +168,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/fsm_and_business_connection/src/main.rs
+++ b/examples/fsm_and_business_connection/src/main.rs
@@ -12,9 +12,9 @@
 //!
 //! More information about FSM you can find in [`telers::fsm`] and [`FSMContextMiddleware`] documentation.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package fsm_and_business_connection
+//! BOT_TOKEN={your_bot_token} cargo run --package fsm_and_business_connection
 //! ```
 
 use telers::{
@@ -24,14 +24,15 @@ use telers::{
         EventReturn,
     },
     filters::{Command, MessageType, State as StateFilter},
-    fsm::{Context as FSMContext, MemoryStorage, Storage, Strategy::UserInChatAndConnection},
+    fsm::{Context as FSMContext, MemoryStorage, Strategy::UserInChatAndConnection},
     methods::SendMessage,
     middlewares::outer::FSMContext as FSMContextMiddleware,
     types::{Message, MessageText},
     Bot, Dispatcher, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
+
+/// Shorthand for the FSM context with in-memory storage. Replace `MemoryStorage` with your own `Storage` impl if needed.
+type FSM = FSMContext<MemoryStorage>;
 
 /// State of conversation.
 ///
@@ -64,11 +65,7 @@ impl PartialEq<&str> for State {
     }
 }
 
-async fn start_handler<S: Storage>(
-    bot: Bot,
-    message: Message,
-    fsm: FSMContext<S>,
-) -> HandlerResult {
+async fn start_handler(bot: Bot, message: Message, fsm: FSM) -> HandlerResult {
     bot.send(
         SendMessage::new(message.chat().id(), "Hello! What's your name?").business_connection_id(
             message.business_connection_id().expect(
@@ -82,24 +79,18 @@ async fn start_handler<S: Storage>(
     // We set state to `State::Name` to point that we are waiting for user's name.
     // `name_handler` will be called when user will send message,
     // because we set `State::Name` as state and this handler is registered for this state
-    fsm.set_state(State::Name).await.map_err(Into::into)?;
+    fsm.set_state(State::Name).await?;
 
     Ok(EventReturn::Finish)
 }
 
-async fn name_handler<S: Storage>(
-    bot: Bot,
-    message: MessageText,
-    fsm: FSMContext<S>,
-) -> HandlerResult {
+async fn name_handler(bot: Bot, message: MessageText, fsm: FSM) -> HandlerResult {
     let name = message.text;
 
     // Save name to FSM storage, because we will need it in `language_handler`
-    fsm.set_value("name", name.clone())
-        .await
-        .map_err(Into::into)?;
+    fsm.set_value("name", name.clone()).await?;
     // Set state to `State::Language` to point that we are waiting for user's language
-    fsm.set_state(State::Language).await.map_err(Into::into)?;
+    fsm.set_state(State::Language).await?;
 
     // Usually state and data set to FSM storage before sending message to user,
     // because we want to be sure that we will receive message from user in the same state
@@ -120,20 +111,12 @@ async fn name_handler<S: Storage>(
     Ok(EventReturn::Finish)
 }
 
-async fn language_handler<S: Storage>(
-    bot: Bot,
-    message: MessageText,
-    fsm: FSMContext<S>,
-) -> HandlerResult {
+async fn language_handler(bot: Bot, message: MessageText, fsm: FSM) -> HandlerResult {
     let language = message.text;
 
     // Get user's name from FSM storage
     // TODO: Add validation, e.g. check that name isn't empty
-    let name: Box<str> = fsm
-        .get_value("name")
-        .await
-        .map_err(Into::into)?
-        .expect("Name should be set");
+    let name: Box<str> = fsm.get_value("name").await?.expect("Name should be set");
 
     // Check if user's language is acceptable
     match language.to_lowercase().as_str() {
@@ -148,7 +131,7 @@ async fn language_handler<S: Storage>(
             .await?;
 
             // Remove state and data from FSM storage, because we don't need them anymore
-            fsm.finish().await.map_err(Into::into)?;
+            fsm.finish().await?;
         }
         _ => {
             bot.send(
@@ -164,7 +147,7 @@ async fn language_handler<S: Storage>(
             .await?;
 
             // We don't need this, because `State::Language` is already set and doesn't change automatically
-            // fsm.set_state(State::Language).await.map_err(Into::into)?;
+            // fsm.set_state(State::Language).await?;
         }
     }
 
@@ -173,12 +156,9 @@ async fn language_handler<S: Storage>(
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     // You can use any storage, which implements `Storage` trait
     let storage = MemoryStorage::new();
@@ -193,13 +173,13 @@ async fn main() {
         .register(FSMContextMiddleware::new(storage).strategy(UserInChatAndConnection));
 
     router.business_message.registers([
-        Handler::new(start_handler::<MemoryStorage>)
+        Handler::new(start_handler)
             .filter(Command::one("start"))
             .filter(StateFilter::none()),
-        Handler::new(name_handler::<MemoryStorage>)
+        Handler::new(name_handler)
             .filter(MessageType::one(Text))
             .filter(StateFilter::one(State::Name)),
-        Handler::new(language_handler::<MemoryStorage>)
+        Handler::new(language_handler)
             .filter(MessageType::one(Text))
             .filter(StateFilter::one(State::Language)),
     ]);
@@ -211,7 +191,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/input_file/src/main.rs
+++ b/examples/input_file/src/main.rs
@@ -1,8 +1,8 @@
 //! This example shows how to use [`InputFile`] and send files by the bot.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package input_file
+//! BOT_TOKEN={your_bot_token} cargo run --package input_file
 //! ```
 
 use bytes::BytesMut;
@@ -17,8 +17,6 @@ use telers::{
     Bot, Dispatcher,
 };
 use tokio_util::codec::{BytesCodec, FramedRead};
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 const CAT_URL: &str = "https://http.cat/images/200.jpg";
 const CAT_FS_PATH: &str = "cat.jpg";
@@ -29,33 +27,28 @@ const DEFAULT_CAPACITY: usize = 64 * 1024; // 64 KiB
 /// It will download file from URL and save it to the file system as `cat.jpg` for further usage in handlers.
 async fn on_startup() -> simple::HandlerResult {
     let response = reqwest::get(CAT_URL).await.map_err(|err| {
-        event!(Level::ERROR, url = CAT_URL, error = %err, "Failed to download file");
-
+        tracing::error!(url = CAT_URL, error = %err, "Failed to download file");
         HandlerError::new(err)
     })?;
 
     let bytes = response.bytes().await.map_err(|err| {
-        event!(Level::ERROR, error = %err, "Failed to read file bytes");
-
+        tracing::error!(error = %err, "Failed to read file bytes");
         HandlerError::new(err)
     })?;
 
     let mut file = tokio::fs::File::create(CAT_FS_PATH).await.map_err(|err| {
-        event!(Level::ERROR, path = CAT_FS_PATH, error = %err, "Failed to create file");
-
+        tracing::error!(path = CAT_FS_PATH, error = %err, "Failed to create file");
         HandlerError::new(err)
     })?;
 
     tokio::io::copy(&mut bytes.as_ref(), &mut file)
         .await
         .map_err(|err| {
-            event!(Level::ERROR, error = %err, path = CAT_FS_PATH, "Failed to write file");
-
+            tracing::error!(error = %err, path = CAT_FS_PATH, "Failed to write file");
             HandlerError::new(err)
         })?;
 
-    event!(
-        Level::INFO,
+    tracing::info!(
         url = CAT_URL,
         path = CAT_FS_PATH,
         "File downloaded and saved to file system"
@@ -68,16 +61,11 @@ async fn on_startup() -> simple::HandlerResult {
 /// It will remove file from file system, which was downloaded on bot startup.
 async fn on_shutdown() -> simple::HandlerResult {
     tokio::fs::remove_file(CAT_FS_PATH).await.map_err(|err| {
-        event!(Level::ERROR, error = %err, path = CAT_FS_PATH, "Failed to remove file");
-
+        tracing::error!(Levelerror = %err, path = CAT_FS_PATH, "Failed to remove file");
         HandlerError::new(err)
     })?;
 
-    event!(
-        Level::INFO,
-        path = CAT_FS_PATH,
-        "File removed from file system"
-    );
+    tracing::info!(path = CAT_FS_PATH, "File removed from file system");
 
     Ok(())
 }
@@ -92,8 +80,7 @@ async fn input_file_handler(bot: Bot, message: Message) -> telegram::HandlerResu
     // Using `InputFile::buffered` to send file by bytes
     let cat_buffered_input_file =
         InputFile::buffered(tokio::fs::read(CAT_FS_PATH).await.map_err(|err| {
-            event!(Level::ERROR, error = %err, "Failed to read file bytes");
-
+            tracing::error!(error = %err, "Failed to read file bytes");
             HandlerError::new(err)
         })?);
 
@@ -137,12 +124,9 @@ async fn input_file_handler(bot: Bot, message: Message) -> telegram::HandlerResu
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = Router::new("main");
     router
@@ -152,6 +136,7 @@ async fn main() {
     router
         .startup
         .register(simple::Handler::new(on_startup, ()));
+
     router
         .shutdown
         .register(simple::Handler::new(on_shutdown, ()));
@@ -163,7 +148,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/random_sticker/src/main.rs
+++ b/examples/random_sticker/src/main.rs
@@ -1,9 +1,9 @@
 //! This example shows how to use the `Stickers` and `StickerSet`
 //! types and how to use the Telegram bot API methods for processing stickers.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package random_sticker
+//! BOT_TOKEN={your_bot_token} cargo run --package random_sticker
 //! ```
 
 use rand::Rng;
@@ -22,8 +22,6 @@ use telers::{
     types::{InputFile, Message, MessageSticker, MessageText},
     Bot, Dispatcher, Filter, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 /// This handler send greeting message to chat.
 async fn start_handler(bot: Bot, message: MessageText) -> HandlerResult {
@@ -84,12 +82,9 @@ async fn wrong_message_handler(bot: Bot, message: Message) -> HandlerResult {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = Router::new("main");
 
@@ -111,7 +106,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/router_tree/src/main.rs
+++ b/examples/router_tree/src/main.rs
@@ -4,9 +4,9 @@
 //! When update is received, it is passed to the main router, which will pass it to the first child router, which can handle this update.
 //! If child router can't handle this update, it will pass it to the next child router, and so on.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package router_tree
+//! BOT_TOKEN={your_bot_token} cargo run --package router_tree
 //! ```
 
 use std::sync::{
@@ -26,8 +26,6 @@ use telers::{
     types::Message,
     Bot, Context, Dispatcher, Request, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 /// This middleware will count all incoming updates, which are handled by echo router.
 #[derive(Default, Clone)]
@@ -37,7 +35,7 @@ struct IncomingEchoRouterUpdates {
 
 impl OuterMiddleware for IncomingEchoRouterUpdates {
     async fn call(&mut self, mut request: Request) -> Result<MiddlewareResponse, EventErrorKind> {
-        event!(Level::INFO, "Incoming echo router update");
+        tracing::info!("Incoming echo router update");
 
         self.counter.fetch_add(1, Ordering::SeqCst);
 
@@ -87,12 +85,9 @@ async fn stats_echo_router(bot: Bot, message: Message, context: Context) -> Hand
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut main_router = Router::new("main");
 
@@ -133,7 +128,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/serialize/src/main.rs
+++ b/examples/serialize/src/main.rs
@@ -1,8 +1,8 @@
 //! This example shows how to serialize Telegram types.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package serialize
+//! BOT_TOKEN={your_bot_token} cargo run --package serialize
 //! ```
 
 use telers::{
@@ -17,9 +17,6 @@ use telers::{
     utils::text::{html_pre_language, html_quote},
     Bot, Dispatcher, Router,
 };
-
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 async fn serialize_handler(bot: Bot, update: Update) -> HandlerResult {
     if let Some(chat) = update.chat() {
@@ -48,12 +45,9 @@ async fn serialize_handler(bot: Bot, update: Update) -> HandlerResult {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = Router::new("main");
     router.update.register(Handler::new(serialize_handler));
@@ -65,7 +59,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/skip_updates/src/main.rs
+++ b/examples/skip_updates/src/main.rs
@@ -1,8 +1,8 @@
 //! This example shows how to create a bot that skips updates and only processes new updates.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package skip_updates
+//! BOT_TOKEN={your_bot_token} cargo run --package skip_updates
 //! ```
 
 use telers::{
@@ -15,22 +15,17 @@ use telers::{
     types::Update,
     Bot, Dispatcher, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 async fn handler(update: Update) -> HandlerResult {
-    event!(Level::INFO, ?update, "Received update");
+    tracing::info!(?update, "Received update");
     Ok(EventReturn::Finish)
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = Router::new("main");
     router.update.register(Handler::new(handler));
@@ -46,7 +41,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/stats_incoming_updates_middleware/src/main.rs
+++ b/examples/stats_incoming_updates_middleware/src/main.rs
@@ -3,9 +3,9 @@
 //! [`ProcessedHandlers`] middleware counter increments when a handler successfully processed.
 //! Every counterer is passes to the handler in the context.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package stats_incoming_updates_middleware
+//! BOT_TOKEN={your_bot_token} cargo run --package stats_incoming_updates_middleware
 //! ```
 
 use std::sync::{
@@ -24,8 +24,6 @@ use telers::{
     types::Update,
     Bot, Context, Dispatcher, Request, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 #[derive(Default, Clone)]
 struct IncomingUpdates {
@@ -87,14 +85,12 @@ async fn handler(bot: Bot, update: Update, context: Context) -> HandlerResult {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = Router::new("main");
+
     // Register inner middleware for all telegram observers
     router
         .telegram_observers_mut()
@@ -104,6 +100,7 @@ async fn main() {
                 .inner_middlewares
                 .register(ProcessedHandlers::default());
         });
+
     // Register outer middleware for update
     router
         .update
@@ -119,7 +116,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/text_case_filters/src/main.rs
+++ b/examples/text_case_filters/src/main.rs
@@ -1,9 +1,9 @@
 //! This example shows how to create text case filters.
 //! First filter checks if the message is uppercase, second filter checks if the message is lowercase.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package text_case_filters
+//! BOT_TOKEN={your_bot_token} cargo run --package text_case_filters
 //! ```
 
 use std::future::Future;
@@ -17,8 +17,6 @@ use telers::{
     types::Message,
     Bot, Dispatcher, Filter, Request, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 #[derive(Clone)]
 struct UppercaseFilter;
@@ -64,12 +62,9 @@ async fn any_case_handler(bot: Bot, message: Message) -> HandlerResult {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = Router::new("main");
     router.message.registers([
@@ -85,7 +80,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }

--- a/examples/text_formatting/src/main.rs
+++ b/examples/text_formatting/src/main.rs
@@ -1,9 +1,9 @@
 //! This example shows how to format text sending by the bot.
 //! In this example we use HTML formatting, but you can use Markdown formatting too, but you can't use both formatting in one message.
 //!
-//! You can run this example by setting `BOT_TOKEN` and optional `RUST_LOG` environment variable and running:
+//! You can run this example by setting `BOT_TOKEN` and running:
 //! ```bash
-//! RUST_LOG={log_level} BOT_TOKEN={your_bot_token} cargo run --package text_formatting
+//! BOT_TOKEN={your_bot_token} cargo run --package text_formatting
 //! ```
 
 use telers::{
@@ -17,8 +17,6 @@ use telers::{
     utils::text::{html_text_link, Builder as TextBuilder, Formatter as _, HTMLFormatter},
     Bot, Dispatcher, Router,
 };
-use tracing::{event, Level};
-use tracing_subscriber::{fmt, layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 async fn handler(bot: Bot, message: Message) -> HandlerResult {
     // First way to format text by using formatting directly in the text.
@@ -38,6 +36,7 @@ async fn handler(bot: Bot, message: Message) -> HandlerResult {
         .text(" text.\nThis is ")
         .text_link("link", "https://example.com")
         .text(".");
+
     let text = text_builder.get_text();
 
     bot.send(SendMessage::new(message.chat().id(), text).parse_mode(ParseMode::HTML))
@@ -62,12 +61,9 @@ async fn handler(bot: Bot, message: Message) -> HandlerResult {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    tracing_subscriber::registry()
-        .with(fmt::layer())
-        .with(EnvFilter::from_env("RUST_LOG"))
-        .init();
+    tracing_subscriber::fmt().init();
 
-    let bot = Bot::from_env_by_key("BOT_TOKEN");
+    let bot = Bot::from_env();
 
     let mut router = Router::new("main");
     router.message.register(Handler::new(handler));
@@ -79,7 +75,7 @@ async fn main() {
         .build();
 
     match dispatcher.run_polling().await {
-        Ok(()) => event!(Level::INFO, "Bot stopped"),
-        Err(err) => event!(Level::ERROR, error = %err, "Bot stopped"),
+        Ok(()) => tracing::info!("Bot stopped"),
+        Err(err) => tracing::error!(error = %err, "Bot stopped"),
     }
 }


### PR DESCRIPTION
## Summary
- use `Bot::from_env()` instead of `Bot::from_env_by_key("BOT_TOKEN")` across all examples.
- replace verbose tracing subscriber setup with `tracing_subscriber::fmt().init()`.
- use `tracing::{info!,warn,error,debug}!` macros directly instead of `event!(Level::INFO, ...)`