### PR TITLE
Add error handler (#60)

### DIFF
--- a/examples/dialogs_mega/src/dialogs/calendar.rs
+++ b/examples/dialogs_mega/src/dialogs/calendar.rs
@@ -39,70 +39,42 @@ fn selected_date_text(data: &DataMap) -> String {
 fn custom_calendar_label(kind: CalendarButtonKind) -> String {
     match kind {
         CalendarButtonKind::Empty => " ".to_owned(),
-        CalendarButtonKind::Weekday {
-            weekday,
-        } => weekday
+        CalendarButtonKind::Weekday { weekday } => weekday
             .to_string()
             .chars()
             .take(2)
             .collect::<String>()
             .to_uppercase(),
-        CalendarButtonKind::DaysHeader {
-            month,
-        } => {
+        CalendarButtonKind::DaysHeader { month } => {
             format!("✦ {} {} ✦", month.month(), month.year())
         }
-        CalendarButtonKind::Day {
-            date,
-            is_today,
-        } => {
+        CalendarButtonKind::Day { date, is_today } => {
             if is_today {
                 format!("·{:02}·", date.day())
             } else {
                 format!("{:02}", date.day())
             }
         }
-        CalendarButtonKind::DaysPrevMonth {
-            ..
-        } => "◀ Prev".to_owned(),
-        CalendarButtonKind::DaysNextMonth {
-            ..
-        } => "Next ▶".to_owned(),
-        CalendarButtonKind::DaysZoom {
-            ..
+        CalendarButtonKind::DaysPrevMonth { .. } => "◀ Prev".to_owned(),
+        CalendarButtonKind::DaysNextMonth { .. } => "Next ▶".to_owned(),
+        CalendarButtonKind::DaysZoom { .. } | CalendarButtonKind::MonthsZoom { .. } => {
+            "🔍".to_owned()
         }
-        | CalendarButtonKind::MonthsZoom {
-            ..
-        } => "🔍".to_owned(),
-        CalendarButtonKind::MonthsHeader {
-            year,
-        } => format!("✦ {year} ✦"),
-        CalendarButtonKind::Month {
-            month,
-            is_current,
-        } => {
+        CalendarButtonKind::MonthsHeader { year } => format!("✦ {year} ✦"),
+        CalendarButtonKind::Month { month, is_current } => {
             if is_current {
                 format!("·{}·", month.month())
             } else {
                 month.month().to_string()
             }
         }
-        CalendarButtonKind::MonthsPrevYear {
-            ..
+        CalendarButtonKind::MonthsPrevYear { .. } | CalendarButtonKind::YearsPrevPage { .. } => {
+            "◀".to_owned()
         }
-        | CalendarButtonKind::YearsPrevPage {
-            ..
-        } => "◀".to_owned(),
-        CalendarButtonKind::MonthsNextYear {
-            ..
+        CalendarButtonKind::MonthsNextYear { .. } | CalendarButtonKind::YearsNextPage { .. } => {
+            "▶".to_owned()
         }
-        | CalendarButtonKind::YearsNextPage {
-            ..
-        } => "▶".to_owned(),
-        CalendarButtonKind::Year {
-            year,
-            is_current,
-        } => {
+        CalendarButtonKind::Year { year, is_current } => {
             if is_current {
                 format!("·{year}·")
             } else {

--- a/telers-codegen/src/generator/methods.rs
+++ b/telers-codegen/src/generator/methods.rs
@@ -124,15 +124,11 @@ impl PrepareStepKind {
     #[must_use]
     fn required_tokens(self, field_name: &Ident) -> TokenStream {
         match self {
-            Self::Single {
-                function_name, ..
-            } => {
+            Self::Single { function_name, .. } => {
                 let function = format_ident!("{function_name}");
                 quote! { super::#function(&mut files, &mut self.#field_name); }
             }
-            Self::Group {
-                function_name, ..
-            } => {
+            Self::Group { function_name, .. } => {
                 let function = format_ident!("{function_name}");
                 quote! { super::#function(&mut files, self.#field_name.iter_mut().collect()); }
             }

--- a/telers-codegen/src/generator/type_utils.rs
+++ b/telers-codegen/src/generator/type_utils.rs
@@ -16,10 +16,7 @@ impl<'a> HelperFieldSource<'a> {
     #[must_use]
     pub fn field(self) -> &'a NormalizedField {
         match self {
-            HelperFieldSource::Direct(field)
-            | HelperFieldSource::EnumHelper {
-                field, ..
-            } => field,
+            HelperFieldSource::Direct(field) | HelperFieldSource::EnumHelper { field, .. } => field,
         }
     }
 
@@ -27,9 +24,7 @@ impl<'a> HelperFieldSource<'a> {
     pub fn required(self) -> bool {
         match self {
             HelperFieldSource::Direct(field) => field.required,
-            HelperFieldSource::EnumHelper {
-                fully_required, ..
-            } => fully_required,
+            HelperFieldSource::EnumHelper { fully_required, .. } => fully_required,
         }
     }
 }

--- a/telers-codegen/src/generator/types.rs
+++ b/telers-codegen/src/generator/types.rs
@@ -187,17 +187,10 @@ fn tokenize_type_definition(type_quote: &NormalizedType, ctx: &TypeDocContext<'_
         }
     } else {
         let serde_attr = match &type_quote.subtype_kind {
-            Some(SubtypeKind::Tagged {
-                tag_field, ..
-            }) => {
+            Some(SubtypeKind::Tagged { tag_field, .. }) => {
                 quote! { #[serde(tag = #tag_field, rename_all = "snake_case")] }
             }
-            Some(
-                SubtypeKind::Untagged
-                | SubtypeKind::UntaggedInTagged {
-                    ..
-                },
-            ) => {
+            Some(SubtypeKind::Untagged | SubtypeKind::UntaggedInTagged { .. }) => {
                 quote! { #[serde(untagged)] }
             }
             None => quote! {},
@@ -1217,9 +1210,7 @@ fn get_helper_impls_for_type(
                         AccessExpr::WrapInSome(tokens) => {
                             quote! { { let inner = self.#outer_ident(); Some(#tokens) } }
                         }
-                        AccessExpr::EnumMethod {
-                            ..
-                        } => {
+                        AccessExpr::EnumMethod { .. } => {
                             unreachable!("enum method access handled in the enum delegation branch",)
                         }
                     }
@@ -1231,9 +1222,7 @@ fn get_helper_impls_for_type(
                         AccessExpr::Optional(tokens) => {
                             quote! { self.#outer_ident().and_then(|inner| #tokens) }
                         }
-                        AccessExpr::EnumMethod {
-                            ..
-                        } => {
+                        AccessExpr::EnumMethod { .. } => {
                             unreachable!("enum method access handled in the enum delegation branch",)
                         }
                     }

--- a/telers-codegen/src/generator/types_helpers/smart_filter.rs
+++ b/telers-codegen/src/generator/types_helpers/smart_filter.rs
@@ -114,9 +114,7 @@ fn enum_method_specs(
                 .iter()
                 .filter_map(|(subtype, field)| match field {
                     HelperFieldSource::Direct(field) => Some((*subtype, *field)),
-                    HelperFieldSource::EnumHelper {
-                        ..
-                    } => None,
+                    HelperFieldSource::EnumHelper { .. } => None,
                 })
                 .collect();
 

--- a/telers-codegen/src/parser/api.rs
+++ b/telers-codegen/src/parser/api.rs
@@ -425,9 +425,7 @@ impl SubtypeKind {
     pub fn get_tags(&self) -> (Option<&str>, Option<&str>) {
         match self {
             SubtypeKind::Untagged => (None, None),
-            SubtypeKind::UntaggedInTagged {
-                tag_field,
-            } => (Some(tag_field.as_str()), None),
+            SubtypeKind::UntaggedInTagged { tag_field } => (Some(tag_field.as_str()), None),
             SubtypeKind::Tagged {
                 tag_field,
                 parent_tag_field,
@@ -798,10 +796,7 @@ impl NormalizedSchema {
                     .collect();
 
             let type_name = format!("{name}Unknown");
-            if let Some(SubtypeKind::Tagged {
-                tag_field, ..
-            }) = &ty.subtype_kind
-            {
+            if let Some(SubtypeKind::Tagged { tag_field, .. }) = &ty.subtype_kind {
                 // The tag field's description is cloned from the first variant and claims a
                 // concrete value (e.g. `always "solid"`); here it holds the unrecognized value.
                 for field in &mut common_fields {
@@ -1814,9 +1809,7 @@ impl NormalizedSchema {
             .as_ref()
             .unwrap()
         {
-            SubtypeKind::Tagged {
-                tag_field, ..
-            } => tag_field.to_owned(),
+            SubtypeKind::Tagged { tag_field, .. } => tag_field.to_owned(),
             _ => unreachable!(),
         };
 

--- a/telers-dialog/src/errors.rs
+++ b/telers-dialog/src/errors.rs
@@ -72,10 +72,7 @@ mod tests {
     #[test]
     fn access_denied_message() {
         assert_eq!(
-            DialogError::AccessDenied {
-                user_id: 5
-            }
-            .to_string(),
+            DialogError::AccessDenied { user_id: 5 }.to_string(),
             "Access denied for user 5"
         );
     }

--- a/telers-dialog/src/manager.rs
+++ b/telers-dialog/src/manager.rs
@@ -340,11 +340,7 @@ impl<S: Storage> DialogManager<S> {
                     needs_show = true;
                     outcome.handled = true;
                 }
-                ButtonAction::Start {
-                    state,
-                    data,
-                    mode,
-                } => {
+                ButtonAction::Start { state, data, mode } => {
                     let _ = self.start(bot, state, data, mode).await?;
                     outcome.handled = true;
                     outcome.already_shown = true;
@@ -364,10 +360,7 @@ impl<S: Storage> DialogManager<S> {
                     needs_show = true;
                     outcome.handled = true;
                 }
-                ButtonAction::SetDialogValue {
-                    key,
-                    value,
-                } => {
+                ButtonAction::SetDialogValue { key, value } => {
                     self.set_dialog_value(key, value).await?;
                     needs_show = true;
                     outcome.handled = true;
@@ -382,10 +375,7 @@ impl<S: Storage> DialogManager<S> {
                     needs_show = true;
                     outcome.handled = true;
                 }
-                ButtonAction::SetWidgetValue {
-                    key,
-                    value,
-                } => {
+                ButtonAction::SetWidgetValue { key, value } => {
                     self.set_widget_value(key, value).await?;
                     needs_show = true;
                     outcome.handled = true;

--- a/telers-dialog/src/widgets/input/base.rs
+++ b/telers-dialog/src/widgets/input/base.rs
@@ -31,9 +31,7 @@ impl MultiInput {
     #[inline]
     #[must_use]
     pub(crate) const fn new() -> Self {
-        Self {
-            inputs: Vec::new(),
-        }
+        Self { inputs: Vec::new() }
     }
 
     #[must_use]

--- a/telers-dialog/src/widgets/kbd/action.rs
+++ b/telers-dialog/src/widgets/kbd/action.rs
@@ -204,11 +204,7 @@ mod tests {
     #[test]
     fn start_holds_state_data_and_mode() {
         match ButtonAction::start("s", json!(1), StartMode::NewStack) {
-            ButtonAction::Start {
-                state,
-                data,
-                mode,
-            } => {
+            ButtonAction::Start { state, data, mode } => {
                 assert_eq!(state, "s");
                 assert_eq!(data, json!(1));
                 assert_eq!(mode, StartMode::NewStack);
@@ -228,10 +224,7 @@ mod tests {
     #[test]
     fn set_dialog_value_holds_key_and_value() {
         match ButtonAction::set_dialog_value("k", "v") {
-            ButtonAction::SetDialogValue {
-                key,
-                value,
-            } => {
+            ButtonAction::SetDialogValue { key, value } => {
                 assert_eq!(key, "k");
                 assert_eq!(value, json!("v"));
             }
@@ -242,10 +235,7 @@ mod tests {
     #[test]
     fn set_widget_value_holds_key_and_value() {
         match ButtonAction::set_widget_value("k", 3) {
-            ButtonAction::SetWidgetValue {
-                key,
-                value,
-            } => {
+            ButtonAction::SetWidgetValue { key, value } => {
                 assert_eq!(key, "k");
                 assert_eq!(value, json!(3));
             }

--- a/telers-dialog/src/widgets/kbd/calendar.rs
+++ b/telers-dialog/src/widgets/kbd/calendar.rs
@@ -163,9 +163,7 @@ impl CalendarAppearance {
             CalendarTextRenderer,
         >,
     ) -> Self {
-        Self {
-            text_renderer,
-        }
+        Self { text_renderer }
     }
 }
 
@@ -674,9 +672,7 @@ where
             [self
                 .button(
                     render_ctx,
-                    CalendarButtonKind::DaysHeader {
-                        month,
-                    },
+                    CalendarButtonKind::DaysHeader { month },
                     CALLBACK_SCOPE_MONTHS,
                 )
                 .await]
@@ -733,9 +729,7 @@ where
             row.push(
                 self.button(
                     render_ctx,
-                    CalendarButtonKind::Weekday {
-                        weekday,
-                    },
+                    CalendarButtonKind::Weekday { weekday },
                     CALLBACK_NOOP,
                 )
                 .await,
@@ -761,9 +755,7 @@ where
             if let Some(prev) = prev {
                 self.button(
                     render_ctx,
-                    CalendarButtonKind::DaysPrevMonth {
-                        month: prev,
-                    },
+                    CalendarButtonKind::DaysPrevMonth { month: prev },
                     CALLBACK_PREV_MONTH,
                 )
                 .await
@@ -772,18 +764,14 @@ where
             },
             self.button(
                 render_ctx,
-                CalendarButtonKind::DaysZoom {
-                    month: offset,
-                },
+                CalendarButtonKind::DaysZoom { month: offset },
                 CALLBACK_SCOPE_MONTHS,
             )
             .await,
             if let Some(next) = next {
                 self.button(
                     render_ctx,
-                    CalendarButtonKind::DaysNextMonth {
-                        month: next,
-                    },
+                    CalendarButtonKind::DaysNextMonth { month: next },
                     CALLBACK_NEXT_MONTH,
                 )
                 .await
@@ -862,9 +850,7 @@ where
             if can_go_prev {
                 self.button(
                     render_ctx,
-                    CalendarButtonKind::MonthsPrevYear {
-                        year: year - 1,
-                    },
+                    CalendarButtonKind::MonthsPrevYear { year: year - 1 },
                     CALLBACK_PREV_YEAR,
                 )
                 .await
@@ -873,18 +859,14 @@ where
             },
             self.button(
                 render_ctx,
-                CalendarButtonKind::MonthsZoom {
-                    year,
-                },
+                CalendarButtonKind::MonthsZoom { year },
                 CALLBACK_SCOPE_YEARS,
             )
             .await,
             if can_go_next {
                 self.button(
                     render_ctx,
-                    CalendarButtonKind::MonthsNextYear {
-                        year: year + 1,
-                    },
+                    CalendarButtonKind::MonthsNextYear { year: year + 1 },
                     CALLBACK_NEXT_YEAR,
                 )
                 .await
@@ -942,9 +924,7 @@ where
                     if can_go_prev {
                         self.button(
                             render_ctx,
-                            CalendarButtonKind::YearsPrevPage {
-                                year: prev_year,
-                            },
+                            CalendarButtonKind::YearsPrevPage { year: prev_year },
                             CALLBACK_PREV_YEARS_PAGE,
                         )
                         .await
@@ -954,9 +934,7 @@ where
                     if can_go_next {
                         self.button(
                             render_ctx,
-                            CalendarButtonKind::YearsNextPage {
-                                year: next_year,
-                            },
+                            CalendarButtonKind::YearsNextPage { year: next_year },
                             CALLBACK_NEXT_YEARS_PAGE,
                         )
                         .await
@@ -1186,67 +1164,37 @@ fn default_calendar_text_renderer<'a>(
 fn default_calendar_text(kind: CalendarButtonKind, _render_ctx: &RenderContext) -> String {
     match kind {
         CalendarButtonKind::Empty => " ".to_owned(),
-        CalendarButtonKind::Weekday {
-            weekday,
-        } => weekday_label(weekday).to_owned(),
-        CalendarButtonKind::DaysHeader {
-            month,
-        } => month_label(month),
-        CalendarButtonKind::Day {
-            date,
-            is_today,
-        } => {
+        CalendarButtonKind::Weekday { weekday } => weekday_label(weekday).to_owned(),
+        CalendarButtonKind::DaysHeader { month } => month_label(month),
+        CalendarButtonKind::Day { date, is_today } => {
             if is_today {
                 format!("[{:02}]", date.day())
             } else {
                 format!("{:02}", date.day())
             }
         }
-        CalendarButtonKind::DaysPrevMonth {
-            month,
-        } => {
+        CalendarButtonKind::DaysPrevMonth { month } => {
             format!("<< {}", month_year_label(month))
         }
-        CalendarButtonKind::DaysZoom {
-            ..
+        CalendarButtonKind::DaysZoom { .. } | CalendarButtonKind::MonthsZoom { .. } => {
+            "Zoom".to_owned()
         }
-        | CalendarButtonKind::MonthsZoom {
-            ..
-        } => "Zoom".to_owned(),
-        CalendarButtonKind::DaysNextMonth {
-            month,
-        } => {
+        CalendarButtonKind::DaysNextMonth { month } => {
             format!("{} >>", month_year_label(month))
         }
-        CalendarButtonKind::MonthsHeader {
-            year,
-        } => format!("{year}"),
-        CalendarButtonKind::Month {
-            month,
-            is_current,
-        } => {
+        CalendarButtonKind::MonthsHeader { year } => format!("{year}"),
+        CalendarButtonKind::Month { month, is_current } => {
             if is_current {
                 format!("[{}]", month.month())
             } else {
                 month.month().to_string()
             }
         }
-        CalendarButtonKind::MonthsPrevYear {
-            year,
-        }
-        | CalendarButtonKind::YearsPrevPage {
-            year,
-        } => format!("<< {year}"),
-        CalendarButtonKind::MonthsNextYear {
-            year,
-        }
-        | CalendarButtonKind::YearsNextPage {
-            year,
-        } => format!("{year} >>"),
-        CalendarButtonKind::Year {
-            year,
-            is_current,
-        } => {
+        CalendarButtonKind::MonthsPrevYear { year }
+        | CalendarButtonKind::YearsPrevPage { year } => format!("<< {year}"),
+        CalendarButtonKind::MonthsNextYear { year }
+        | CalendarButtonKind::YearsNextPage { year } => format!("{year} >>"),
+        CalendarButtonKind::Year { year, is_current } => {
             if is_current {
                 format!("[ {year} ]")
             } else {
@@ -1370,12 +1318,8 @@ mod tests {
 
     async fn custom_text_renderer(kind: CalendarButtonKind, _render_ctx: RenderContext) -> String {
         match kind {
-            CalendarButtonKind::Day {
-                date, ..
-            } => format!("D{}", date.day()),
-            CalendarButtonKind::Weekday {
-                weekday,
-            } => {
+            CalendarButtonKind::Day { date, .. } => format!("D{}", date.day()),
+            CalendarButtonKind::Weekday { weekday } => {
                 format!("W{}", weekday.number_from_monday())
             }
             _ => "x".to_owned(),

--- a/telers-dialog/src/widgets/kbd/inline_keyboard.rs
+++ b/telers-dialog/src/widgets/kbd/inline_keyboard.rs
@@ -40,10 +40,7 @@ impl InlineKeyboard {
         #[builder(field = Vec::new())] rows: Vec<Vec<Button>>,
         when: Option<WhenCondition>,
     ) -> Self {
-        Self {
-            rows,
-            when,
-        }
+        Self { rows, when }
     }
 }
 

--- a/telers-dialog/src/widgets/kbd/request.rs
+++ b/telers-dialog/src/widgets/kbd/request.rs
@@ -337,10 +337,7 @@ impl ForceReply {
         #[builder(field = ForceReplyOptions::default())] options: ForceReplyOptions,
         when: Option<WhenCondition>,
     ) -> Self {
-        Self {
-            options,
-            when,
-        }
+        Self { options, when }
     }
 }
 

--- a/telers-dialog/src/widgets/media/base.rs
+++ b/telers-dialog/src/widgets/media/base.rs
@@ -219,9 +219,7 @@ impl MultiMedia {
     #[builder]
     #[must_use]
     pub fn new(#[builder(field = Vec::new())] widgets: Vec<Box<dyn Media>>) -> Self {
-        Self {
-            widgets,
-        }
+        Self { widgets }
     }
 }
 

--- a/telers-dialog/src/widgets/text/base.rs
+++ b/telers-dialog/src/widgets/text/base.rs
@@ -61,9 +61,7 @@ impl<Renderer> FnText<Renderer> {
     #[inline]
     #[must_use]
     pub const fn new(renderer: Renderer) -> Self {
-        Self {
-            renderer,
-        }
+        Self { renderer }
     }
 }
 

--- a/telers-dialog/src/widgets/text/multi.rs
+++ b/telers-dialog/src/widgets/text/multi.rs
@@ -36,10 +36,7 @@ impl MultiText {
         #[builder(field)] items: Vec<Box<dyn Text>>,
         #[builder(default = "\n", into)] separator: Cow<'static, str>,
     ) -> Self {
-        Self {
-            items,
-            separator,
-        }
+        Self { items, separator }
     }
 }
 

--- a/telers-dialog/src/widgets/text/template.rs
+++ b/telers-dialog/src/widgets/text/template.rs
@@ -110,9 +110,7 @@ impl TemplateEnvBuilder {
     /// Create a new environment builder seeded with the default settings.
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            env: default_env(),
-        }
+        Self { env: default_env() }
     }
 
     /// Add a custom filter function.

--- a/telers/src/client/session/base.rs
+++ b/telers/src/client/session/base.rs
@@ -184,34 +184,20 @@ pub trait Session: Send + Sync {
         }
 
         let err = match status_code.as_u16() {
-            400 => TelegramErrorKind::BadRequest {
-                message,
-            },
-            401 => TelegramErrorKind::Unauthorized {
-                message,
-            },
-            403 => TelegramErrorKind::Forbidden {
-                message,
-            },
-            404 => TelegramErrorKind::NotFound {
-                message,
-            },
-            409 => TelegramErrorKind::ConflictError {
-                message,
-            },
+            400 => TelegramErrorKind::BadRequest { message },
+            401 => TelegramErrorKind::Unauthorized { message },
+            403 => TelegramErrorKind::Forbidden { message },
+            404 => TelegramErrorKind::NotFound { message },
+            409 => TelegramErrorKind::ConflictError { message },
             413 => TelegramErrorKind::EntityTooLarge {
                 url: "https://core.telegram.org/bots/api#sending-files",
                 message,
             },
             500 => {
                 if message.contains("restart") {
-                    TelegramErrorKind::RestartingTelegram {
-                        message,
-                    }
+                    TelegramErrorKind::RestartingTelegram { message }
                 } else {
-                    TelegramErrorKind::ServerError {
-                        message,
-                    }
+                    TelegramErrorKind::ServerError { message }
                 }
             }
             _ => {

--- a/telers/src/context.rs
+++ b/telers/src/context.rs
@@ -60,9 +60,7 @@ impl Context {
     #[inline]
     #[must_use]
     pub const fn new() -> Self {
-        Self {
-            map: None,
-        }
+        Self { map: None }
     }
 
     pub fn insert<T: Clone + Send + Sync + 'static>(

--- a/telers/src/dispatcher.rs
+++ b/telers/src/dispatcher.rs
@@ -561,9 +561,7 @@ impl<Client, Propagator, BackoffType> ServePolling<Client, Propagator, BackoffTy
     #[inline]
     #[must_use]
     pub const fn new(dispatcher: Dispatcher<Client, Propagator, BackoffType>) -> Self {
-        Self {
-            dispatcher,
-        }
+        Self { dispatcher }
     }
 
     #[inline]
@@ -627,10 +625,7 @@ impl<Client, Propagator, BackoffType, Signal>
         dispatcher: Dispatcher<Client, Propagator, BackoffType>,
         signal: Signal,
     ) -> Self {
-        Self {
-            dispatcher,
-            signal,
-        }
+        Self { dispatcher, signal }
     }
 }
 
@@ -671,9 +666,7 @@ impl<Client, Propagator, BackoffType> Serve<Client, Propagator, BackoffType> {
     #[inline]
     #[must_use]
     pub const fn new(dispatcher: Dispatcher<Client, Propagator, BackoffType>) -> Self {
-        Self {
-            dispatcher,
-        }
+        Self { dispatcher }
     }
 
     #[inline]
@@ -735,10 +728,7 @@ impl<Client, Propagator, BackoffType, Signal>
         dispatcher: Dispatcher<Client, Propagator, BackoffType>,
         signal: Signal,
     ) -> Self {
-        Self {
-            dispatcher,
-            signal,
-        }
+        Self { dispatcher, signal }
     }
 }
 

--- a/telers/src/errors/extractor.rs
+++ b/telers/src/errors/extractor.rs
@@ -21,9 +21,7 @@ pub struct Error {
 
 impl Error {
     pub fn new(msg: impl Into<Cow<'static, str>>) -> Self {
-        Self {
-            msg: msg.into(),
-        }
+        Self { msg: msg.into() }
     }
 }
 

--- a/telers/src/errors/filter.rs
+++ b/telers/src/errors/filter.rs
@@ -28,9 +28,7 @@ impl Error {
     /// # Notes
     /// If you want to pass just a message, you can use [`Error::from_display`] or [`Error::from_debug`] methods.
     pub fn new(err: impl Into<anyhow::Error>) -> Self {
-        Self {
-            source: err.into(),
-        }
+        Self { source: err.into() }
     }
 
     /// # Arguments

--- a/telers/src/errors/handler.rs
+++ b/telers/src/errors/handler.rs
@@ -28,9 +28,7 @@ impl Error {
     /// # Notes
     /// If you want to pass just a message, you can use [`Error::from_display`] or [`Error::from_debug`] methods.
     pub fn new(err: impl Into<anyhow::Error>) -> Self {
-        Self {
-            source: err.into(),
-        }
+        Self { source: err.into() }
     }
 
     /// # Arguments

--- a/telers/src/errors/middleware.rs
+++ b/telers/src/errors/middleware.rs
@@ -31,9 +31,7 @@ impl Error {
     /// # Notes
     /// If you want to pass just a message, you can use [`Error::from_display`] or [`Error::from_debug`] methods.
     pub fn new(err: impl Into<anyhow::Error>) -> Self {
-        Self {
-            source: err.into(),
-        }
+        Self { source: err.into() }
     }
 
     /// # Arguments

--- a/telers/src/event/error/event.rs
+++ b/telers/src/event/error/event.rs
@@ -1,0 +1,18 @@
+use crate::Request;
+use std::sync::Arc;
+
+/// The error that occurred while processing an update, together with the
+/// request that was being processed when it happened.
+pub struct ErrorEvent<Client> {
+    pub request: Request<Client>,
+    pub error: Arc<crate::errors::EventErrorKind>,
+}
+
+impl<Client> Clone for ErrorEvent<Client> {
+    fn clone(&self) -> Self {
+        Self {
+            request: self.request.clone(),
+            error: self.error.clone(),
+        }
+    }
+}

--- a/telers/src/event/error/observer.rs
+++ b/telers/src/event/error/observer.rs
@@ -1,0 +1,112 @@
+use super::{
+    event::ErrorEvent,
+    handler::handler,
+};
+use crate::{errors::HandlerError, event::EventReturn};
+use std::fmt::{self, Debug, Formatter};
+use tracing::{event, instrument, Level};
+
+/// Whether the error was handled by one of the registered error handlers.
+pub enum PropaGateErrorResult<Client> {
+    Handled,
+    Unhandled(ErrorEvent<Client>),
+}
+
+/// Observer for errors that occur while processing an update.
+/// Handlers are called in order of registration; a handler returning
+/// [`EventReturn::Skip`] passes the error to the next handler.
+/// Unlike telegram handlers, error handlers have no filters or middlewares —
+/// they're meant to be a simple, fast last line of defense.
+#[derive(Clone)]
+pub struct Observer<Client> {
+    pub(crate) event_name: &'static str,
+    pub(crate) handlers: Vec<Handler<Client>>,
+}
+
+impl<Client> Observer<Client>
+where 
+Client: Send + Sync + 'static,
+{
+    #[inline]
+    #[must_use]
+    pub const fn new(event_name: &'static str) -> Self {
+        Self {
+            event_name,
+            handlers: vec![],
+        }
+    }
+
+    /// Register error handler
+    #[inline]
+    #[must_use]
+    pub fn register(mut self, handler: Handler<Client>) -> Self {
+        self.handlers.push(handler);
+        self
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn on(self, handler: Handler<Client>) -> Self {
+        self.register(handler)
+    }
+
+
+    /// Register error handler
+    /// # Notes
+    /// Alias to [`Observer::register`] method
+    #[must_use]
+    pub fn registers(mut self, handlers: impl IntoIterator<Item = Handler<Client>>) -> Self {
+        self.handlers.extend(handlers);
+        self
+    }
+}
+
+impl<Client> Observer<Client> {
+    #[inline]
+    #[must_use]
+    pub fn handlers_len(&self) -> usize {
+        self.handlers.len()
+    }
+}
+
+impl<Client> Observer<Client> 
+where
+Client: Clone + Send + Sync + 'static,
+{
+
+    /// Propagate the error to handlers in order of registration.
+    /// Stops on the first handler that doesn't return [`EventReturn::Skip`].
+    /// # Errors
+    /// If any handler returns an error
+    #[instrument(skip_all)]
+    pub async fn trigger(
+        &mut self,
+        event: ErrorEvent<Client>,
+    ) -> Result<PropaGateErrorResult<Client>, HandlerError> {
+        
+        for handler in &mut self.handlers {
+            match handler.call(event.clone()).await? {
+                EventReturn::Skip => {
+                    event!(Level::TRACE, "Error handler return skip.");
+                    continue;
+                }
+                EventReturn::Finish | EventReturn::Cancel => {
+                    event!(Level::TRACE, "Error handler returns Finish/Cancel");
+                    return Ok(PropaGateErrorResult::Handled);
+                }
+            }
+        }
+
+        event!(Level::TRACE, "Error not handled by any handler in this observer");
+        Ok(PropaGateErrorResult::Unhandled(event))
+    }
+}
+
+impl<Client> Debug for Observer<Client> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Observer")
+            .field("event_name", &self.event_name)
+            .field("handlers", &self.handlers.len())
+            .finish_non_exhaustive()
+    }
+}

--- a/telers/src/event/error/simple.rs
+++ b/telers/src/event/error/simple.rs
@@ -1,0 +1,7 @@
+pub mod event;
+pub mod handler;
+pub mod observer;
+
+pub use event::ErrorEvent;
+pub use handler::{Handler, HandlerFn, HandlerResult};
+pub use observer::{Observer, PropagateErrorResult};

--- a/telers/src/extensions.rs
+++ b/telers/src/extensions.rs
@@ -91,9 +91,7 @@ impl Extensions {
     #[inline]
     #[must_use]
     pub const fn new() -> Self {
-        Self {
-            map: None,
-        }
+        Self { map: None }
     }
 
     pub fn insert<T: Clone + Send + Sync + 'static>(&mut self, val: T) -> Option<T> {

--- a/telers/src/filters/chat_member_updated.rs
+++ b/telers/src/filters/chat_member_updated.rs
@@ -13,10 +13,7 @@ impl ChatMemberUpdated {
     #[inline]
     #[must_use]
     pub const fn new(new: ChatMemberType) -> Self {
-        Self {
-            new,
-            old: None,
-        }
+        Self { new, old: None }
     }
 
     #[inline]

--- a/telers/src/fsm/context.rs
+++ b/telers/src/fsm/context.rs
@@ -22,10 +22,7 @@ impl<S> Context<S> {
     #[inline]
     #[must_use]
     pub fn new(storage: S, key: StorageKey) -> Self {
-        Self {
-            storage,
-            key,
-        }
+        Self { storage, key }
     }
 }
 

--- a/telers/src/fsm/storage/base.rs
+++ b/telers/src/fsm/storage/base.rs
@@ -42,10 +42,7 @@ impl StorageKey {
     #[inline]
     #[must_use]
     pub fn destiny(self, destiny: &'static str) -> Self {
-        Self {
-            destiny,
-            ..self
-        }
+        Self { destiny, ..self }
     }
 }
 

--- a/telers/src/fsm/storage/memory.rs
+++ b/telers/src/fsm/storage/memory.rs
@@ -567,15 +567,11 @@ mod tests {
         let value1 = AOption {
             a: Some("a".to_owned()),
         };
-        let value2 = AOption {
-            a: None,
-        };
+        let value2 = AOption { a: None };
         let value3 = AOptionSkip {
             a: Some("a".to_owned()),
         };
-        let value4 = AOptionSkip {
-            a: None,
-        };
+        let value4 = AOptionSkip { a: None };
 
         storage
             .set_value(&key1, "key1", value1.clone())

--- a/telers/src/fsm/storage/redis.rs
+++ b/telers/src/fsm/storage/redis.rs
@@ -79,19 +79,13 @@ impl KeyBuilderImpl {
     #[inline]
     #[must_use]
     pub fn with_prefix(self, prefix: &'static str) -> Self {
-        Self {
-            prefix,
-            ..self
-        }
+        Self { prefix, ..self }
     }
 
     #[inline]
     #[must_use]
     pub fn with_separator(self, separator: &'static str) -> Self {
-        Self {
-            separator,
-            ..self
-        }
+        Self { separator, ..self }
     }
 
     #[inline]
@@ -199,10 +193,7 @@ impl<K: KeyBuilder> Redis<K> {
             },
         };
 
-        Ok(Self {
-            pool,
-            key_builder,
-        })
+        Ok(Self { pool, key_builder })
     }
 
     #[inline]

--- a/telers/src/methods/delete_sticker_set.rs
+++ b/telers/src/methods/delete_sticker_set.rs
@@ -17,9 +17,7 @@ impl DeleteStickerSet {
     /// * `name` - Sticker set name
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(name: T0) -> Self {
-        Self {
-            name: name.into(),
-        }
+        Self { name: name.into() }
     }
 
     /// Sticker set name

--- a/telers/src/methods/get_chat_menu_button.rs
+++ b/telers/src/methods/get_chat_menu_button.rs
@@ -18,9 +18,7 @@ impl GetChatMenuButton {
     /// Use builder methods to set optional fields.
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            chat_id: None,
-        }
+        Self { chat_id: None }
     }
 
     /// Unique identifier for the target private chat. If not specified, the bot's default menu button will be returned.

--- a/telers/src/methods/get_my_default_administrator_rights.rs
+++ b/telers/src/methods/get_my_default_administrator_rights.rs
@@ -18,9 +18,7 @@ impl GetMyDefaultAdministratorRights {
     /// Use builder methods to set optional fields.
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            for_channels: None,
-        }
+        Self { for_channels: None }
     }
 
     /// Pass `true` to get default administrator rights of the bot in channels. Otherwise, default administrator rights of the bot for groups and supergroups will be returned.

--- a/telers/src/methods/get_sticker_set.rs
+++ b/telers/src/methods/get_sticker_set.rs
@@ -17,9 +17,7 @@ impl GetStickerSet {
     /// * `name` - Name of the sticker set
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(name: T0) -> Self {
-        Self {
-            name: name.into(),
-        }
+        Self { name: name.into() }
     }
 
     /// Name of the sticker set

--- a/telers/src/types/bot_name.rs
+++ b/telers/src/types/bot_name.rs
@@ -14,9 +14,7 @@ impl BotName {
     /// * `name` - The bot's name
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(name: T0) -> Self {
-        Self {
-            name: name.into(),
-        }
+        Self { name: name.into() }
     }
 
     /// The bot's name

--- a/telers/src/types/chat_owner_left.rs
+++ b/telers/src/types/chat_owner_left.rs
@@ -15,9 +15,7 @@ impl ChatOwnerLeft {
     /// Use builder methods to set optional fields.
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            new_owner: None,
-        }
+        Self { new_owner: None }
     }
 
     /// The user who will become the new owner of the chat if the previous owner does not return to the chat

--- a/telers/src/types/copy_text_button.rs
+++ b/telers/src/types/copy_text_button.rs
@@ -14,9 +14,7 @@ impl CopyTextButton {
     /// * `text` - The text to be copied to the clipboard; 1-256 characters
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(text: T0) -> Self {
-        Self {
-            text: text.into(),
-        }
+        Self { text: text.into() }
     }
 
     /// The text to be copied to the clipboard; 1-256 characters

--- a/telers/src/types/input_media_link.rs
+++ b/telers/src/types/input_media_link.rs
@@ -14,9 +14,7 @@ impl InputMediaLink {
     /// * `url` - HTTP URL of the link
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(url: T0) -> Self {
-        Self {
-            url: url.into(),
-        }
+        Self { url: url.into() }
     }
 
     /// HTTP URL of the link

--- a/telers/src/types/input_rich_block_anchor.rs
+++ b/telers/src/types/input_rich_block_anchor.rs
@@ -14,9 +14,7 @@ impl InputRichBlockAnchor {
     /// * `name` - The name of the anchor
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(name: T0) -> Self {
-        Self {
-            name: name.into(),
-        }
+        Self { name: name.into() }
     }
 
     /// The name of the anchor

--- a/telers/src/types/keyboard_button_poll_type.rs
+++ b/telers/src/types/keyboard_button_poll_type.rs
@@ -15,9 +15,7 @@ impl KeyboardButtonPollType {
     /// Use builder methods to set optional fields.
     #[must_use]
     pub fn new() -> Self {
-        Self {
-            r#type: None,
-        }
+        Self { r#type: None }
     }
 
     /// If quiz is passed, the user will be allowed to create only polls in the quiz mode. If regular is passed, only regular polls will be allowed. Otherwise, the user will be allowed to create a poll of any type.

--- a/telers/src/types/link.rs
+++ b/telers/src/types/link.rs
@@ -14,9 +14,7 @@ impl Link {
     /// * `url` - URL of the link
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(url: T0) -> Self {
-        Self {
-            url: url.into(),
-        }
+        Self { url: url.into() }
     }
 
     /// URL of the link

--- a/telers/src/types/non_telegram/input_file.rs
+++ b/telers/src/types/non_telegram/input_file.rs
@@ -230,9 +230,7 @@ pub struct FileId {
 impl FileId {
     #[must_use]
     pub fn new(id: impl Into<String>) -> Self {
-        Self {
-            id: id.into(),
-        }
+        Self { id: id.into() }
     }
 
     #[must_use]
@@ -269,9 +267,7 @@ pub struct UrlFile {
 impl UrlFile {
     #[must_use]
     pub fn new(url: impl Into<String>) -> Self {
-        Self {
-            url: url.into(),
-        }
+        Self { url: url.into() }
     }
 
     #[must_use]

--- a/telers/src/types/poll_media_link.rs
+++ b/telers/src/types/poll_media_link.rs
@@ -16,9 +16,7 @@ impl PollMediaLink {
     /// * `link` - The HTTP link attached to the poll option
     #[must_use]
     pub fn new<T0: Into<crate::types::Link>>(link: T0) -> Self {
-        Self {
-            link: link.into(),
-        }
+        Self { link: link.into() }
     }
 
     /// The HTTP link attached to the poll option

--- a/telers/src/types/prepared_keyboard_button.rs
+++ b/telers/src/types/prepared_keyboard_button.rs
@@ -14,9 +14,7 @@ impl PreparedKeyboardButton {
     /// * `id` - Unique identifier of the keyboard button
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(id: T0) -> Self {
-        Self {
-            id: id.into(),
-        }
+        Self { id: id.into() }
     }
 
     /// Unique identifier of the keyboard button

--- a/telers/src/types/rich_block_anchor.rs
+++ b/telers/src/types/rich_block_anchor.rs
@@ -14,9 +14,7 @@ impl RichBlockAnchor {
     /// * `name` - The name of the anchor
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(name: T0) -> Self {
-        Self {
-            name: name.into(),
-        }
+        Self { name: name.into() }
     }
 
     /// The name of the anchor

--- a/telers/src/types/rich_text_anchor.rs
+++ b/telers/src/types/rich_text_anchor.rs
@@ -14,9 +14,7 @@ impl RichTextAnchor {
     /// * `name` - The name of the anchor
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(name: T0) -> Self {
-        Self {
-            name: name.into(),
-        }
+        Self { name: name.into() }
     }
 
     /// The name of the anchor

--- a/telers/src/types/story_area_type_link.rs
+++ b/telers/src/types/story_area_type_link.rs
@@ -14,9 +14,7 @@ impl StoryAreaTypeLink {
     /// * `url` - HTTP or `tg`:// URL to be opened when the area is clicked
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(url: T0) -> Self {
-        Self {
-            url: url.into(),
-        }
+        Self { url: url.into() }
     }
 
     /// HTTP or `tg`:// URL to be opened when the area is clicked

--- a/telers/src/types/story_area_type_unique_gift.rs
+++ b/telers/src/types/story_area_type_unique_gift.rs
@@ -14,9 +14,7 @@ impl StoryAreaTypeUniqueGift {
     /// * `name` - Unique name of the gift
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(name: T0) -> Self {
-        Self {
-            name: name.into(),
-        }
+        Self { name: name.into() }
     }
 
     /// Unique name of the gift

--- a/telers/src/types/web_app_info.rs
+++ b/telers/src/types/web_app_info.rs
@@ -14,9 +14,7 @@ impl WebAppInfo {
     /// * `url` - An HTTPS URL of a Web App to be opened with additional data as specified in Initializing Web Apps
     #[must_use]
     pub fn new<T0: Into<Box<str>>>(url: T0) -> Self {
-        Self {
-            url: url.into(),
-        }
+        Self { url: url.into() }
     }
 
     /// An HTTPS URL of a Web App to be opened with additional data as specified in Initializing Web Apps

--- a/telers/src/utils/chat_action.rs
+++ b/telers/src/utils/chat_action.rs
@@ -176,9 +176,7 @@ where
             }
         });
 
-        ChatActionGuard {
-            handle,
-        }
+        ChatActionGuard { handle }
     }
 }
 

--- a/telers/src/utils/text/render/html.rs
+++ b/telers/src/utils/text/render/html.rs
@@ -90,10 +90,7 @@ fn write_tag(tag: &Tag, buf: &mut String) {
             Place::MidNewLine => unreachable!(),
             Place::End => buf.push_str(HTML.custom_emoji.end),
         },
-        Kind::DateTime {
-            unix_time,
-            format,
-        } => match tag.place {
+        Kind::DateTime { unix_time, format } => match tag.place {
             Place::Start => match format {
                 Some(format) => write!(
                     buf,

--- a/telers/src/utils/text/render/markdown.rs
+++ b/telers/src/utils/text/render/markdown.rs
@@ -94,10 +94,7 @@ fn write_tag(tag: &Tag, buf: &mut String) {
                 .unwrap();
             }
         },
-        Kind::DateTime {
-            unix_time,
-            format,
-        } => match tag.place {
+        Kind::DateTime { unix_time, format } => match tag.place {
             Place::Start => buf.push_str(MARKDOWN.date_time.start),
             Place::MidNewLine => unreachable!(),
             Place::End => match format {

--- a/telers/src/utils/text/render/mod.rs
+++ b/telers/src/utils/text/render/mod.rs
@@ -91,10 +91,7 @@ impl<'a> Renderer<'a> {
 
         tags.sort_unstable();
 
-        Self {
-            text,
-            tags,
-        }
+        Self { text, tags }
     }
 
     /// Renders the text with the given [`TagWriter`], inserting tags at their UTF-16 offsets.

--- a/telers/src/utils/text/render/tag.rs
+++ b/telers/src/utils/text/render/tag.rs
@@ -109,10 +109,7 @@ pub(crate) struct SimpleTag {
 
 impl SimpleTag {
     pub const fn new(start: &'static str, end: &'static str) -> Self {
-        Self {
-            start,
-            end,
-        }
+        Self { start, end }
     }
 
     pub fn get_tag(&self, place: Place) -> &'static str {
@@ -133,11 +130,7 @@ pub(crate) struct ComplexTag {
 
 impl ComplexTag {
     pub const fn new(start: &'static str, middle: &'static str, end: &'static str) -> Self {
-        Self {
-            start,
-            middle,
-            end,
-        }
+        Self { start, middle, end }
     }
 }
 
@@ -175,11 +168,7 @@ pub(crate) struct NewLineRepeatedTag {
 
 impl NewLineRepeatedTag {
     pub const fn new(start: &'static str, repeat: &'static str, end: &'static str) -> Self {
-        Self {
-            start,
-            repeat,
-            end,
-        }
+        Self { start, repeat, end }
     }
 }
 

--- a/telers/src/webhooks/axum/handler.rs
+++ b/telers/src/webhooks/axum/handler.rs
@@ -116,10 +116,7 @@ where
             };
             let update = match serde_json::from_str::<Either<Update, UpdateUnparsed>>(&update_raw) {
                 Ok(Left(update)) => update,
-                Ok(Right(UpdateUnparsed {
-                    update_id,
-                    extra,
-                })) => {
+                Ok(Right(UpdateUnparsed { update_id, extra })) => {
                     event!(
                         Level::ERROR,
                         update_id,


### PR DESCRIPTION
Add error handler (#60)

Added error handling like requested in #60, new folder src/event/error/ with event.rs, observer.rs, handler.rs.

ErrorEvent holds the request + the error that happened. Observer lets you register handlers, they run in the order you added them, if one returns Skip it just goes to the next one, Finish/Cancel means it's handled and stops there.

Didn't add filters/middleware for this one on purpose, wanted it simple and fast since it's basically the last thing that runs when something goes wrong.

Closes #60